### PR TITLE
add visual build status que to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Super Mario War
 
+[![Build status](https://travis-ci.org/mmatyas/supermariowar.svg?branch=master)](https://travis-ci.org/mmatyas/supermariowar)
+
 - [About](#about)
 - [Get the code](#get-the-code)
 - [Building](#building-instructions)


### PR DESCRIPTION
shows the building pass or failed logo from travis ci on the readme for an easier indication on the current build status.