### PR TITLE
Use MSYS2 on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,66 +11,37 @@ environment:
     - USE_SDL2: true
     - USE_SDL2: false
 
-matrix:
-  allow_failures:
-    - platform: x64
-
 install:
   - git submodule update --init --recursive
-  - echo Installing dependencies
-  - choco install -y 7zip
-  - set PATH="C:\Program Files\7-Zip";C:\MinGW\bin;%PATH%
-  # Set up Zlib
-  - appveyor DownloadFile http://sourceforge.net/projects/mingw/files/MinGW/Base/zlib/zlib-1.2.8/zlib-1.2.8-1-mingw32-dev.tar.lzma
-  - 7z x zlib-1.2.8-1-mingw32-dev.tar.lzma
-  - 7z x -ozlib zlib-1.2.8-1-mingw32-dev.tar
-  # Set up SDL 1.2 libs
-  - if [%USE_SDL2%]==[false] ( echo Setting up SDL 1.2.x )
-  - if [%USE_SDL2%]==[false] ( appveyor DownloadFile https://www.libsdl.org/release/SDL-devel-1.2.15-mingw32.tar.gz )
-  - if [%USE_SDL2%]==[false] ( appveyor DownloadFile https://www.libsdl.org/projects/SDL_image/release/SDL_image-devel-1.2.12-VC.zip )
-  - if [%USE_SDL2%]==[false] ( appveyor DownloadFile https://www.libsdl.org/projects/SDL_mixer/release/SDL_mixer-devel-1.2.12-VC.zip )
-  - if [%USE_SDL2%]==[false] ( 7z x SDL-devel-1.2.15-mingw32.tar.gz )
-  - if [%USE_SDL2%]==[false] ( 7z x -xr!._\* -xr!man -xr!docs SDL-devel-1.2.15-mingw32.tar )
-  - if [%USE_SDL2%]==[false] ( 7z x SDL_image-devel-1.2.12-VC.zip )
-  - if [%USE_SDL2%]==[false] ( 7z x SDL_mixer-devel-1.2.12-VC.zip )
-  - if [%USE_SDL2%]==[false] ( xcopy /S/Y SDL_image-1.2.12 SDL-1.2.15 )
-  - if [%USE_SDL2%]==[false] ( xcopy /S/Y SDL_mixer-1.2.12 SDL-1.2.15 )
-  - if [%USE_SDL2%]==[false] ( set SDLDIR=%CD%\SDL-1.2.15 )
-  - if [%USE_SDL2%]==[false] ( echo SDLDIR set to %SDLDIR% )
-  # Set up SDL2 libs
-  - if [%USE_SDL2%]==[true] ( echo Setting up SDL2 )
-  - if [%USE_SDL2%]==[true] ( appveyor DownloadFile https://www.libsdl.org/release/SDL2-devel-2.0.4-mingw.tar.gz )
-  - if [%USE_SDL2%]==[true] ( appveyor DownloadFile https://www.libsdl.org/projects/SDL_image/release/SDL2_image-devel-2.0.1-mingw.tar.gz )
-  - if [%USE_SDL2%]==[true] ( appveyor DownloadFile https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-devel-2.0.1-mingw.tar.gz )
-  - if [%USE_SDL2%]==[true] ( 7z x SDL2-devel-2.0.4-mingw.tar.gz )
-  - if [%USE_SDL2%]==[true] ( 7z x -xr!._\* -xr!man -xr!docs SDL2-devel-2.0.4-mingw.tar )
-  - if [%USE_SDL2%]==[true] ( 7z x SDL2_image-devel-2.0.1-mingw.tar.gz )
-  - if [%USE_SDL2%]==[true] ( 7z x -xr!._\* -xr!man -xr!docs SDL2_image-devel-2.0.1-mingw.tar )
-  - if [%USE_SDL2%]==[true] ( 7z x SDL2_mixer-devel-2.0.1-mingw.tar.gz )
-  - if [%USE_SDL2%]==[true] ( 7z x -xr!._\* -xr!man -xr!docs SDL2_mixer-devel-2.0.1-mingw.tar )
-  - if [%USE_SDL2%]==[true] ( xcopy /S/Y SDL2_image-2.0.1 SDL2-2.0.4 )
-  - if [%USE_SDL2%]==[true] ( xcopy /S/Y SDL2_mixer-2.0.1 SDL2-2.0.4 )
-  - if [%USE_SDL2%]==[true] (
-      if [%PLATFORM%]==[x86] ( set SDL2DIR=%CD%\SDL2-2.0.4\i686-w64-mingw32 )
-      else ( set SDL2DIR=%CD%\SDL2-2.0.4\x86_64-w64-mingw32 ) )
-  - if [%USE_SDL2%]==[true] ( echo SDL2DIR set to %SDL2DIR% )
+  - set PATH=C:\msys64\usr\bin;C:\msys64\mingw64\bin;%PATH
+  - set MINGW_ARCH=i686
+  - if [%PLATFORM%]==[x64] set MINGW_ARCH=x86_64
+  - set MINGW_SDL=SDL
+  - if [%USE_SDL2%]==[true] set MINGW_SDL=SDL2
+  - pacman --noconfirm --needed -Sy
+      pkg-config
+      mingw-w64-%MINGW_ARCH%-toolchain
+      mingw-w64-%MINGW_ARCH%-cmake
+      mingw-w64-%MINGW_ARCH%-zlib
+      mingw-w64-%MINGW_ARCH%-%MINGW_SDL%
+      mingw-w64-%MINGW_ARCH%-%MINGW_SDL%_image
+      mingw-w64-%MINGW_ARCH%-%MINGW_SDL%_mixer
 
 build_script:
+  - set MSYSTEM=MINGW32
+  - if [%PLATFORM%]==[x64] set MSYSTEM=MINGW64
+  - cmake --version
+  - make --version
+  - mkdir build
   - if [%USE_SDL2%]==[false] (
-    C:\MinGW\msys\1.0\bin\sh --login -c "
-      cd /c/projects/supermariowar;
-      mkdir build;
-      cd build;
-      cmake --version;
-      CFLAGS=-D_hypot=hypot CXXFLAGS=-D_hypot=hypot cmake .. -G 'MSYS Makefiles' -DZLIB_ROOT=/c/projects/supermariowar/zlib;
-      cmake --build ." )
+    bash -lc "
+      cd $APPVEYOR_BUILD_FOLDER/build;
+      cmake .. -G 'Unix Makefiles';
+      make" )
   - if [%USE_SDL2%]==[true] (
-    C:\MinGW\msys\1.0\bin\sh --login -c "
-      cd /c/projects/supermariowar;
-      mkdir build;
-      cd build;
-      cmake --version;
-      CFLAGS=-D_hypot=hypot CXXFLAGS=-D_hypot=hypot cmake .. -G 'MSYS Makefiles' -DZLIB_ROOT=/c/projects/supermariowar/zlib -DUSE_SDL2_LIBS=1;
+    bash -lc "
+      cd $APPVEYOR_BUILD_FOLDER/build;
+      cmake .. -G 'Unix Makefiles' -DUSE_SDL2_LIBS=1;
       make smw" )
 
 artifacts:


### PR DESCRIPTION
Pros:
- Cleaner file
- No need for manual download, extract and path setup
- Fixes SDL2 + x64 build
- Fixes `_hypot`

Cons:
- Slowwww
- Static linking doesn't work
