### PR TITLE
Fix starman and hurry up sounds in SDL2

### DIFF
--- a/src/smw/GSGameplay.cpp
+++ b/src/smw/GSGameplay.cpp
@@ -169,12 +169,15 @@ void DECLSPEC musicfinished()
         return;
 
     if (game_values.gamestate == GS_GAME && !game_values.gamemode->gameover) {
+        return;
+        /*
         if (game_values.playnextmusic) {
             musiclist->SetNextMusic(g_map->musicCategoryID, maplist->currentShortmapname(), g_map->szBackgroundFile);
             rm->backgroundmusic[0].load(musiclist->GetCurrentMusic()); //In Game Music
         }
 
         rm->backgroundmusic[0].play(game_values.playnextmusic, false);
+        */
     } else {
         if (fResumeMusic) {
             rm->backgroundmusic[3].play(false, false);


### PR DESCRIPTION
Fixes #82 
The commented out code already exists in playMusic(), and doesn't even need to be here.