### PR TITLE
Fix USE_PNG_SAVE flag.

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -36,7 +36,7 @@ set(COMMON_SRCS
 )
 
 if (USE_PNG_SAVE)
-    list(APPEND COMMON_SRCS src/savepng.cpp)
+    list(APPEND COMMON_SRCS savepng.cpp)
 endif()
 
 add_library(CommonFiles ${COMMON_SRCS})


### PR DESCRIPTION
Build files aren't generated correctly when the USE_PNG_SAVE flag is set. This fixes the USE_PNG_SAVE flag. 