### PR TITLE
Fix having to press escape twice to exit controls menu

### DIFF
--- a/src/smw/ui/MI_InputControlContainer.cpp
+++ b/src/smw/ui/MI_InputControlContainer.cpp
@@ -424,7 +424,7 @@ MI_InputControlContainer::MI_InputControlContainer(gfxSprite * spr_button, short
     miBackButton->SetCode(MENU_CODE_BACK_TO_CONTROLS_MENU);
 
     mInputMenu = new UI_Menu();
-    mInputMenu->SetCancelCode(MENU_CODE_CANCEL_INPUT);
+    mInputMenu->SetCancelCode(MENU_CODE_BACK_TO_CONTROLS_MENU);
     mInputMenu->AddNonControl(miImage[0]);
     mInputMenu->AddNonControl(miImage[1]);
     mInputMenu->AddNonControl(miText);


### PR DESCRIPTION
This fixes the bug where when you enter the controls menu and select any of the players, you needed to press escape twice to exit the menu. If you pressed escape only once, the menu would just lock up until you pressed it again.