### PR TITLE
Fix UI not rearranging itself after beating boss.

### DIFF
--- a/src/smw/gamemodes.cpp
+++ b/src/smw/gamemodes.cpp
@@ -3199,6 +3199,7 @@ bool CGM_Boss_MiniGame::SetWinner(CPlayer * player)
     }
 
     SetupScoreBoard(false);
+    ShowScoreBoard();
 
     if (game_values.music) {
         ifsoundonstop(rm->sfx_invinciblemusic);


### PR DESCRIPTION
ShowScoreBoard() is called every single time after SetupScoreBoard() except here.