### PR TITLE
Fix resizing worlds crashing the world editor

### DIFF
--- a/src/smw/world.cpp
+++ b/src/smw/world.cpp
@@ -1065,46 +1065,40 @@ void WorldMap::New(short w, short h)
 void WorldMap::Resize(short w, short h)
 {
     //Copy tiles from old map
-    WorldMapTile ** tempTiles = NULL;
+    WorldMapTile ** tempTiles = tiles;
     short iOldWidth = iWidth;
     short iOldHeight = iHeight;
 
-    if (tiles) {
-        tempTiles = new WorldMapTile*[w];
-
-        for (short iCol = 0; iCol < w && iCol < iOldWidth; iCol++) {
-            tempTiles[iCol] = new WorldMapTile[h];
-
-            for (short iRow = 0; iRow < h && iRow < iOldHeight; iRow++) {
-                tempTiles[iCol][iRow].iBackgroundSprite = tiles[iCol][iRow].iBackgroundSprite;
-                tempTiles[iCol][iRow].iBackgroundWater = tiles[iCol][iRow].iBackgroundWater;
-                tempTiles[iCol][iRow].iForegroundSprite = tiles[iCol][iRow].iForegroundSprite;
-                tempTiles[iCol][iRow].iConnectionType = tiles[iCol][iRow].iConnectionType;
-                tempTiles[iCol][iRow].iType = tiles[iCol][iRow].iType;
-            }
-        }
-    }
-
     //Create new map
-    New(w, h);
+    iWidth = w;
+    iHeight = h;
 
-    //Copy into new map
-    if (tempTiles) {
-        for (short iCol = 0; iCol < w && iCol < iOldWidth; iCol++) {
-            for (short iRow = 0; iRow < h && iRow < iOldHeight; iRow++) {
-                tiles[iCol][iRow].iBackgroundSprite = tempTiles[iCol][iRow].iBackgroundSprite;
-                tiles[iCol][iRow].iBackgroundWater = tempTiles[iCol][iRow].iBackgroundWater;
-                tiles[iCol][iRow].iForegroundSprite = tempTiles[iCol][iRow].iForegroundSprite;
-                tiles[iCol][iRow].iConnectionType = tempTiles[iCol][iRow].iConnectionType;
-                tiles[iCol][iRow].iType = tempTiles[iCol][iRow].iType;
+    tiles = new WorldMapTile*[iWidth];
+
+    for (short iCol = 0; iCol < iWidth; iCol++)
+        tiles[iCol] = new WorldMapTile[iHeight];
+
+    for (short iCol = 0; iCol < w; iCol++) {
+        if (iCol < iOldWidth) {
+            for (short iRow = 0; iRow < h; iRow++) {
+                if (iRow < iOldHeight)
+                    tiles[iCol][iRow] = tempTiles[iCol][iRow];
+                else {
+                    tiles[iCol][iRow].iBackgroundSprite = 0;
+                    tiles[iCol][iRow].iBackgroundWater = 0;
+                    tiles[iCol][iRow].iForegroundSprite = 0;
+                    tiles[iCol][iRow].iConnectionType = 0;
+                    tiles[iCol][iRow].iType = 0;
+                    tiles[iCol][iRow].iID = iRow * iWidth + iCol;
+                    tiles[iCol][iRow].iVehicleBoundary = 0;
+                    tiles[iCol][iRow].iWarp = 0;
+                }
             }
         }
-
-        for (short iCol = 0; iCol < w; iCol++)
-            delete [] tempTiles[iCol];
-
-        delete [] tempTiles;
+        else
+            tiles[iCol] = new WorldMapTile[h];
     }
+
 }
 
 void WorldMap::InitPlayer()

--- a/src/smw/world.cpp
+++ b/src/smw/world.cpp
@@ -1075,11 +1075,10 @@ void WorldMap::Resize(short w, short h)
 
     tiles = new WorldMapTile*[iWidth];
 
-    for (short iCol = 0; iCol < iWidth; iCol++)
+    //Copy tiles to new map
+    for (short iCol = 0; iCol < iWidth; iCol++) {
         tiles[iCol] = new WorldMapTile[iHeight];
-
-    for (short iCol = 0; iCol < w; iCol++) {
-        for (short iRow = 0; iRow < h; iRow++) {
+        for (short iRow = 0; iRow < iHeight; iRow++) {
             if (iCol < iOldWidth && iRow < iOldHeight)
                 tiles[iCol][iRow] = tempTiles[iCol][iRow];
             else {

--- a/src/smw/world.cpp
+++ b/src/smw/world.cpp
@@ -1094,6 +1094,13 @@ void WorldMap::Resize(short w, short h)
         }
     }
 
+    //Delete old tiles
+    if (tempTiles) {
+        for (short iCol = 0; iCol < iOldWidth; iCol++)
+            delete [] tempTiles[iCol];
+
+        delete [] tempTiles;
+    }
 }
 
 void WorldMap::InitPlayer()

--- a/src/smw/world.cpp
+++ b/src/smw/world.cpp
@@ -1079,24 +1079,20 @@ void WorldMap::Resize(short w, short h)
         tiles[iCol] = new WorldMapTile[iHeight];
 
     for (short iCol = 0; iCol < w; iCol++) {
-        if (iCol < iOldWidth) {
-            for (short iRow = 0; iRow < h; iRow++) {
-                if (iRow < iOldHeight)
-                    tiles[iCol][iRow] = tempTiles[iCol][iRow];
-                else {
-                    tiles[iCol][iRow].iBackgroundSprite = 0;
-                    tiles[iCol][iRow].iBackgroundWater = 0;
-                    tiles[iCol][iRow].iForegroundSprite = 0;
-                    tiles[iCol][iRow].iConnectionType = 0;
-                    tiles[iCol][iRow].iType = 0;
-                    tiles[iCol][iRow].iID = iRow * iWidth + iCol;
-                    tiles[iCol][iRow].iVehicleBoundary = 0;
-                    tiles[iCol][iRow].iWarp = 0;
-                }
+        for (short iRow = 0; iRow < h; iRow++) {
+            if (iCol < iOldWidth && iRow < iOldHeight)
+                tiles[iCol][iRow] = tempTiles[iCol][iRow];
+            else {
+                tiles[iCol][iRow].iBackgroundSprite = 0;
+                tiles[iCol][iRow].iBackgroundWater = 0;
+                tiles[iCol][iRow].iForegroundSprite = 0;
+                tiles[iCol][iRow].iConnectionType = 0;
+                tiles[iCol][iRow].iType = 0;
+                tiles[iCol][iRow].iID = iRow * iWidth + iCol;
+                tiles[iCol][iRow].iVehicleBoundary = 0;
+                tiles[iCol][iRow].iWarp = 0;
             }
         }
-        else
-            tiles[iCol] = new WorldMapTile[h];
     }
 
 }

--- a/src/worldeditor/worldeditor.cpp
+++ b/src/worldeditor/worldeditor.cpp
@@ -4777,6 +4777,20 @@ int resize_world()
 		if (iHeight < 1)
 			iHeight = 1;
 
+		std::vector<WorldVehicle*>::iterator itrVehicle = vehiclelist.begin(), limVehicle = vehiclelist.end();
+        while (itrVehicle != limVehicle) {
+			if ((*itrVehicle)->iCurrentTileX >= iWidth || (*itrVehicle)->iCurrentTileY >= iHeight) {
+				RemoveVehicleFromTile((*itrVehicle)->iCurrentTileX, (*itrVehicle)->iCurrentTileY);
+				//List was modified, restart.
+				itrVehicle = vehiclelist.begin();
+				limVehicle = vehiclelist.end();
+			}
+			else
+				itrVehicle++;
+		}
+
+		warplist.clear();
+
 		g_worldmap.Resize(iWidth, iHeight);
 
 		savecurrentworld();

--- a/src/worldeditor/worldeditor.cpp
+++ b/src/worldeditor/worldeditor.cpp
@@ -4789,6 +4789,11 @@ int resize_world()
 				itrVehicle++;
 		}
 
+		std::vector<WorldWarp*>::iterator itrWarp = warplist.begin(), limWarp = warplist.end();
+        while (itrWarp != limWarp) {
+			delete (*itrWarp);
+			itrWarp++;
+		}
 		warplist.clear();
 
 		g_worldmap.Resize(iWidth, iHeight);

--- a/src/worldeditor/worldeditor.cpp
+++ b/src/worldeditor/worldeditor.cpp
@@ -4777,24 +4777,6 @@ int resize_world()
 		if (iHeight < 1)
 			iHeight = 1;
 
-		std::vector<WorldVehicle*>::iterator itrVehicle = vehiclelist.begin(), limVehicle = vehiclelist.end();
-        while (itrVehicle != limVehicle) {
-			if ((*itrVehicle)->iCurrentTileX >= iWidth || (*itrVehicle)->iCurrentTileY >= iHeight)
-				RemoveVehicleFromTile((*itrVehicle)->iCurrentTileX, (*itrVehicle)->iCurrentTileY);
-
-			itrVehicle++;
-		}
-
-		std::vector<WorldWarp*>::iterator itrWarp = warplist.begin(), limWarp = warplist.end();
-        while (itrWarp != limWarp) {
-			delete (*itrWarp);
-
-			itrWarp = warplist.erase(itrWarp);
-			limWarp = warplist.end();
-
-			itrWarp++;
-		}
-
 		g_worldmap.Resize(iWidth, iHeight);
 
 		savecurrentworld();


### PR DESCRIPTION
The resize world code was doing lots of strange things, like deleting some vehicles/warps, then deleting them all later when New was called, so I just rewrote it. The code that was crashing is the code I deleted from worldeditor.cpp.