### PR TITLE
Fix player physics bugs

### DIFF
--- a/src/smw/player.cpp
+++ b/src/smw/player.cpp
@@ -200,7 +200,7 @@ void CPlayer::accelerate(float direction)
     }
     assert(maxVel >= 0.0);
 
-    if (std::abs(velx) > maxVel)
+    if ((direction == 1 && velx > maxVel) || (direction == -1 && velx < -maxVel))
         velx = maxVel * direction;
 
     if (!inair) {


### PR DESCRIPTION
Someone refactored this line with a non-equivalent absolute value check, which caused two physics bugs:
1) You don't bounce off the sides of note blocks when you walk into them.
2) You can sometimes change your direction instantly at full speed if your let go of the run button at the right time.