### PR TITLE
Fix cursor being visible in game in SDL2

### DIFF
--- a/src/common/gfx/gfxSDL.cpp
+++ b/src/common/gfx/gfxSDL.cpp
@@ -250,7 +250,6 @@ void GraphicsSDL::create_game_window(bool fullscreen)
 void GraphicsSDL::setTitle(const char* title)
 {
     SDL_WM_SetCaption(title, "smw.ico");
-    SDL_ShowCursor(SDL_DISABLE);
 }
 
 void GraphicsSDL::FlipScreen()

--- a/src/smw/main.cpp
+++ b/src/smw/main.cpp
@@ -311,6 +311,7 @@ int main(int argc, char *argv[])
     char title[128];
     sprintf(title, "%s %s", TITLESTRING, VERSIONNUMBER);
     gfx_settitle(title);
+    SDL_ShowCursor(SDL_DISABLE);
 
     printf("\n---------------- loading ----------------\n");
 


### PR DESCRIPTION
This line is not SDL 1.2.x specific, so it should be moved.