### PR TITLE
Fix editor fullscreen mode bugs in SDL2

### DIFF
--- a/src/leveleditor/leveleditor.cpp
+++ b/src/leveleditor/leveleditor.cpp
@@ -167,13 +167,12 @@ short			y_shake = 0;
 int				mouse_x, mouse_y;
 
 void update_mouse_coords() {
-#ifdef USE_SDL2
-	mouse_x = (std::min)(640 - 1, (std::max)(event.motion.x, 0));
-	mouse_y = (std::min)(480 - 1, (std::max)(event.motion.y, 0));
-#else
 	mouse_x = event.motion.x;
 	mouse_y = event.motion.y;
-#endif
+	if (mouse_x < 0) mouse_x = 0;
+	if (mouse_y < 0) mouse_y = 0;
+	if (mouse_x > 640 - 1) mouse_x = 640 - 1;
+	if (mouse_y > 480 - 1) mouse_y = 480 - 1;
 }
 
 CEyecandyContainer eyecandy[3];

--- a/src/leveleditor/leveleditor.cpp
+++ b/src/leveleditor/leveleditor.cpp
@@ -64,6 +64,7 @@ void removeifprojectile(IO_MovingObject * object, bool playsound, bool forcedead
 #ifdef _WIN32
 	#include <windows.h>
     #ifdef _MSC_VER
+    #define NOMINMAX
     #if _MSC_VER >= 1400
         #include <stdio.h>
         FILE _iob[] = {*stdin, *stdout, *stderr};

--- a/src/leveleditor/leveleditor.cpp
+++ b/src/leveleditor/leveleditor.cpp
@@ -64,7 +64,6 @@ void removeifprojectile(IO_MovingObject * object, bool playsound, bool forcedead
 #ifdef _WIN32
 	#include <windows.h>
     #ifdef _MSC_VER
-    #define NOMINMAX
     #if _MSC_VER >= 1400
         #include <stdio.h>
         FILE _iob[] = {*stdin, *stdout, *stderr};
@@ -169,8 +168,8 @@ int				mouse_x, mouse_y;
 
 void update_mouse_coords() {
 #ifdef USE_SDL2
-	mouse_x = std::min(640 - 1, std::max(event.motion.x, 0));
-	mouse_y = std::min(480 - 1, std::max(event.motion.y, 0));
+	mouse_x = (std::min)(640 - 1, (std::max)(event.motion.x, 0));
+	mouse_y = (std::min)(480 - 1, (std::max)(event.motion.y, 0));
 #else
 	mouse_x = event.motion.x;
 	mouse_y = event.motion.y;

--- a/src/leveleditor/leveleditor.cpp
+++ b/src/leveleditor/leveleditor.cpp
@@ -164,6 +164,13 @@ int				copiedlayer;
 short			x_shake = 0;
 short			y_shake = 0;
 
+int				mouse_x, mouse_y;
+
+void update_mouse_coords() {
+	mouse_x = std::min(640 - 1, std::max(event.button.x, 0));
+	mouse_y = std::min(480 - 1, std::max(event.button.y, 0));
+}
+
 CEyecandyContainer eyecandy[3];
 CGameMode		*gamemodes[GAMEMODE_LAST];
 CPlayer			*list_players[4];
@@ -950,9 +957,8 @@ int editor_edit()
 
                     if (key == SDLK_k) {
 							int iMouseX, iMouseY;
-							SDL_GetMouseState(&iMouseX, &iMouseY);
-							iMouseX >>= 5;
-							iMouseY >>= 5;
+							iMouseX = mouse_x / TILESIZE;
+							iMouseY = mouse_y / TILESIZE;
 
 							short iType = g_map->objectdata[iMouseX][iMouseY].iType;
                         if (iType == 1 || iType == 15 || iType == 4 || iType == 5 || iType == 17 || iType == 18 || iType == 3) {
@@ -1344,6 +1350,7 @@ int editor_edit()
 					}
 
                 case SDL_MOUSEMOTION: {
+						update_mouse_coords();
 						short iClickX = event.button.x / TILESIZE;
 						short iClickY = event.button.y / TILESIZE;
 
@@ -1478,15 +1485,11 @@ int editor_edit()
 			}
 
             if (move_mode == 1 || move_mode == 3) {
-				int mousex, mousey;
-				SDL_GetMouseState(&mousex, &mousey);
-				move_offset_x = (mousex / TILESIZE) - move_start_x;
-				move_offset_y = (mousey / TILESIZE) - move_start_y;
+				move_offset_x = (mouse_x / TILESIZE) - move_start_x;
+				move_offset_y = (mouse_y / TILESIZE) - move_start_y;
             } else if (move_mode == 2) {
-				int mousex, mousey;
-				SDL_GetMouseState(&mousex, &mousey);
-				move_drag_offset_x = (mousex / TILESIZE);
-				move_drag_offset_y = (mousey / TILESIZE);
+				move_drag_offset_x = (mouse_x / TILESIZE);
+				move_drag_offset_y = (mouse_y / TILESIZE);
 			}
 
 		}
@@ -1957,6 +1960,11 @@ int editor_eyecandy()
 					break;
 				}
 
+			case SDL_MOUSEMOTION: {
+				update_mouse_coords();
+				break;
+				}
+
 				default:
 					break;
 			}
@@ -1966,15 +1974,12 @@ int editor_eyecandy()
 		drawmap(false, TILESIZE);
 		rm->menu_shade.draw(0, 0);
 
-		int iMouseX, iMouseY;
-		SDL_GetMouseState(&iMouseX, &iMouseY);
-
 		short ix = 165;
         for (short iLayer = 0; iLayer < 3; iLayer++) {
             for (short k = 0; k < NUM_EYECANDY; k++) {
 				short iy = k * 65 + 20;
 
-				if (iMouseX >= ix && iMouseX < ix + 90 && iMouseY >= iy && iMouseY < iy + 52)
+				if (mouse_x >= ix && mouse_x < ix + 90 && mouse_y >= iy && mouse_y < iy + 52)
 					rm->spr_powerupselector.draw(ix, iy, 0, 0, 90, 52);
 				else
 					rm->spr_powerupselector.draw(ix, iy, 0, 52, 90, 52);
@@ -2050,11 +2055,8 @@ int editor_properties(short iBlockCol, short iBlockRow)
                     editor_properties_initialized = false;
 					return EDITOR_EDIT;
                 } else if ((iBlockType == 1 || iBlockType == 15) && ((event.key.keysym.sym >= SDLK_0 && event.key.keysym.sym <= SDLK_9) || event.key.keysym.sym == SDLK_BACKQUOTE || event.key.keysym.sym == SDLK_d)) {
-						int iMouseX, iMouseY;
-						SDL_GetMouseState(&iMouseX, &iMouseY);
-
 						short iSettingIndex = 0;
-						short * piSetting = GetBlockProperty(iMouseX, iMouseY, iBlockCol, iBlockRow, &iSettingIndex);
+						short * piSetting = GetBlockProperty(mouse_x, mouse_y, iBlockCol, iBlockRow, &iSettingIndex);
 
 						//If shift is held, set all powerups to this setting
 						short iValue = event.key.keysym.sym - SDLK_0;
@@ -2091,8 +2093,7 @@ int editor_properties(short iBlockCol, short iBlockRow)
 						short * piSetting = GetBlockProperty(event.button.x, event.button.y, iBlockCol, iBlockRow, &iSettingIndex);
 
                     if (piSetting) {
-							int iMouseX, iMouseY;
-							Uint8 iMouseState = SDL_GetMouseState(&iMouseX, &iMouseY);
+							Uint8 iMouseState = SDL_GetMouseState(NULL, NULL);
 
 							if ((event.button.button == SDL_BUTTON_RIGHT && (iMouseState & SDL_BUTTON_LMASK)) ||
                                 (event.button.button == SDL_BUTTON_LEFT && (iMouseState & SDL_BUTTON_RMASK))) {
@@ -2132,6 +2133,11 @@ int editor_properties(short iBlockCol, short iBlockRow)
 					break;
 				}
 
+			case SDL_MOUSEMOTION: {
+				update_mouse_coords();
+				break;
+				}
+
 				default:
 					break;
 			}
@@ -2140,9 +2146,6 @@ int editor_properties(short iBlockCol, short iBlockRow)
 
 		drawmap(false, TILESIZE);
 		rm->menu_shade.draw(0, 0);
-
-		int iMouseX, iMouseY;
-		SDL_GetMouseState(&iMouseX, &iMouseY);
 
 		short iHiddenCheckboxY = 0;
 
@@ -2153,7 +2156,7 @@ int editor_properties(short iBlockCol, short iBlockRow)
 				short ix = (iSetting % 6) * 100 + 35;
 				short iy = (iSetting / 6) * 62 + 65;
 
-				if (iMouseX >= ix - 10 && iMouseX < ix + 80 && iMouseY >= iy - 10 && iMouseY < iy + 42 && !fUseGame)
+				if (mouse_x >= ix - 10 && mouse_x < ix + 80 && mouse_y >= iy - 10 && mouse_y < iy + 42 && !fUseGame)
 					rm->spr_powerupselector.draw(ix - 10, iy - 10, 0, 0, 90, 52);
 				else
 					rm->spr_powerupselector.draw(ix - 10, iy - 10, 0, 52, 90, 52);
@@ -2179,7 +2182,7 @@ int editor_properties(short iBlockCol, short iBlockRow)
 			iHiddenCheckboxY = 214;
 		}
 
-		if (iMouseX >= 270 && iMouseX < 370 && iMouseY >= iHiddenCheckboxY && iMouseY < iHiddenCheckboxY + 52)
+		if (mouse_x >= 270 && mouse_x < 370 && mouse_y >= iHiddenCheckboxY && mouse_y < iHiddenCheckboxY + 52)
 			rm->spr_powerupselector.draw(270, iHiddenCheckboxY, 90, 0, 100, 52);
 		else
 			rm->spr_powerupselector.draw(270, iHiddenCheckboxY, 90, 52, 100, 52);
@@ -2191,7 +2194,7 @@ int editor_properties(short iBlockCol, short iBlockRow)
 
 		//Display "Use Game" option
         if (iBlockType == 1 || iBlockType == 15) {
-			if (iMouseX >= 390 && iMouseX < 490 && iMouseY >= iHiddenCheckboxY && iMouseY < iHiddenCheckboxY + 52)
+			if (mouse_x >= 390 && mouse_x < 490 && mouse_y >= iHiddenCheckboxY && mouse_y < iHiddenCheckboxY + 52)
 				rm->spr_powerupselector.draw(390, iHiddenCheckboxY, 90, 0, 100, 52);
 			else
 				rm->spr_powerupselector.draw(390, iHiddenCheckboxY, 90, 52, 100, 52);
@@ -2580,6 +2583,7 @@ int editor_platforms()
 					}
 				}
             case SDL_MOUSEMOTION: {
+					update_mouse_coords();
 					short ix = event.button.x / TILESIZE;
 					short iy = event.button.y / TILESIZE;
 
@@ -3225,6 +3229,7 @@ int editor_maphazards()
 					}
 				}
             case SDL_MOUSEMOTION: {
+					update_mouse_coords();
 					short iClickX = event.button.x;
 					short iClickY = event.button.y;
 
@@ -3583,6 +3588,7 @@ int editor_tiles()
 				}
 
             case SDL_MOUSEMOTION: {
+					update_mouse_coords();
 					short iCol = event.button.x / TILESIZE + view_tileset_x;
 					short iRow = event.button.y / TILESIZE + view_tileset_y;
 
@@ -3925,6 +3931,7 @@ int editor_modeitems()
 				}
 
             case SDL_MOUSEMOTION: {
+                update_mouse_coords();
                 if (dragmodeitem >= 0 && event.motion.state == SDL_BUTTON(SDL_BUTTON_LEFT)) {
                         #if defined(USE_SDL2) || defined(__EMSCRIPTEN__)
                             const Uint8 * keystate = SDL_GetKeyboardState(NULL);
@@ -4147,6 +4154,10 @@ int editor_backgrounds()
 					}
 				break;
 
+				case SDL_MOUSEMOTION:
+					update_mouse_coords();
+				break;
+
 				default:
 					break;
 			}
@@ -4165,11 +4176,7 @@ int editor_backgrounds()
 		rm->menu_font_small.draw(0,480-rm->menu_font_small.getHeight() * 2, "[Page Up] next page, [Page Down] previous page");
 		rm->menu_font_small.draw(0,480-rm->menu_font_small.getHeight(), "[LMB] choose background with music category, [RMB] choose just background");
 
-		int x, y;
-
-		SDL_GetMouseState(&x, &y);
-
-		int iID = x / 160 + y / 120 * 4 + iPage * 16;
+		int iID = mouse_x / 160 + mouse_y / 120 * 4 + iPage * 16;
 
         if (iID < backgroundlist->GetCount())
             rm->menu_font_small.draw(0, 0, backgroundlist->GetIndex(iID));
@@ -4278,6 +4285,7 @@ int editor_animation()
 				}
 
             case SDL_MOUSEMOTION: {
+                update_mouse_coords();
                 if (fInValidTile) {
                     if (event.motion.state == SDL_BUTTON(SDL_BUTTON_LEFT)) {
 							if (iCol < set_tile_start_x)

--- a/src/leveleditor/leveleditor.cpp
+++ b/src/leveleditor/leveleditor.cpp
@@ -61,10 +61,6 @@ void removeifprojectile(IO_MovingObject * object, bool playsound, bool forcedead
 #include <cstring>
 #include <cstdlib>
 
-#ifndef USE_SDL2
-#include <algorithm>
-#endif
-
 #ifdef _WIN32
 	#include <windows.h>
     #ifdef _MSC_VER
@@ -171,8 +167,13 @@ short			y_shake = 0;
 int				mouse_x, mouse_y;
 
 void update_mouse_coords() {
+#ifdef USE_SDL2
 	mouse_x = std::min(640 - 1, std::max(event.motion.x, 0));
 	mouse_y = std::min(480 - 1, std::max(event.motion.y, 0));
+#else
+	mouse_x = event.motion.x;
+	mouse_y = event.motion.y;
+#endif
 }
 
 CEyecandyContainer eyecandy[3];

--- a/src/leveleditor/leveleditor.cpp
+++ b/src/leveleditor/leveleditor.cpp
@@ -61,6 +61,10 @@ void removeifprojectile(IO_MovingObject * object, bool playsound, bool forcedead
 #include <cstring>
 #include <cstdlib>
 
+#ifndef USE_SDL2
+#include <algorithm>
+#endif
+
 #ifdef _WIN32
 	#include <windows.h>
     #ifdef _MSC_VER
@@ -167,8 +171,8 @@ short			y_shake = 0;
 int				mouse_x, mouse_y;
 
 void update_mouse_coords() {
-	mouse_x = std::min(640 - 1, std::max(event.button.x, 0));
-	mouse_y = std::min(480 - 1, std::max(event.button.y, 0));
+	mouse_x = std::min(640 - 1, std::max(event.motion.x, 0));
+	mouse_y = std::min(480 - 1, std::max(event.motion.y, 0));
 }
 
 CEyecandyContainer eyecandy[3];

--- a/src/worldeditor/worldeditor.cpp
+++ b/src/worldeditor/worldeditor.cpp
@@ -44,7 +44,6 @@
 #ifdef _WIN32
 	#include <windows.h>
     #ifdef _MSC_VER
-    #define NOMINMAX
     #if _MSC_VER >= 1400
         #include <stdio.h>
         FILE _iob[] = {*stdin, *stdout, *stderr};
@@ -104,8 +103,8 @@ int				mouse_x, mouse_y;
 
 void update_mouse_coords() {
 #ifdef USE_SDL2
-	mouse_x = std::min(640 - 1, std::max(event.motion.x, 0));
-	mouse_y = std::min(480 - 1, std::max(event.motion.y, 0));
+	mouse_x = (std::min)(640 - 1, (std::max)(event.motion.x, 0));
+	mouse_y = (std::min)(480 - 1, (std::max)(event.motion.y, 0));
 #else
 	mouse_x = event.motion.x;
 	mouse_y = event.motion.y;

--- a/src/worldeditor/worldeditor.cpp
+++ b/src/worldeditor/worldeditor.cpp
@@ -44,6 +44,7 @@
 #ifdef _WIN32
 	#include <windows.h>
     #ifdef _MSC_VER
+    #define NOMINMAX
     #if _MSC_VER >= 1400
         #include <stdio.h>
         FILE _iob[] = {*stdin, *stdout, *stderr};

--- a/src/worldeditor/worldeditor.cpp
+++ b/src/worldeditor/worldeditor.cpp
@@ -101,6 +101,11 @@ WorldMapTile	copiedtiles[MAPWIDTH][MAPHEIGHT];
 
 int				mouse_x, mouse_y;
 
+void update_mouse_coords() {
+	mouse_x = std::min(640 - 1, std::max(event.button.x, 0));
+	mouse_y = std::min(480 - 1, std::max(event.button.y, 0));
+}
+
 //Vehicle structure that holds the current vehicle "stamp"
 WorldVehicle g_wvVehicleStamp;
 
@@ -1489,8 +1494,7 @@ int editor_edit()
 					}
 					//Painting tiles with mouse movement
                 case SDL_MOUSEMOTION: {
-						mouse_x = event.button.x;
-						mouse_y = event.button.y;
+						update_mouse_coords();
 						short iButtonX = event.button.x - draw_offset_x;
 						short iButtonY = event.button.y - draw_offset_y;
 						short iCol = (iButtonX >> 5) + draw_offset_col;
@@ -4019,8 +4023,7 @@ int editor_stage()
 				}
 
             case SDL_MOUSEMOTION: {
-					mouse_x = event.button.x;
-					mouse_y = event.button.y;
+					update_mouse_coords();
 					iStageDisplay = -1;
 
                 if (iEditStage == -1) {

--- a/src/worldeditor/worldeditor.cpp
+++ b/src/worldeditor/worldeditor.cpp
@@ -41,6 +41,10 @@
 #include <string.h>
 #include <ctype.h>
 
+#ifndef USE_SDL2
+#include <algorithm>
+#endif
+
 #ifdef _WIN32
 	#include <windows.h>
     #ifdef _MSC_VER
@@ -102,8 +106,8 @@ WorldMapTile	copiedtiles[MAPWIDTH][MAPHEIGHT];
 int				mouse_x, mouse_y;
 
 void update_mouse_coords() {
-	mouse_x = std::min(640 - 1, std::max(event.button.x, 0));
-	mouse_y = std::min(480 - 1, std::max(event.button.y, 0));
+	mouse_x = std::min(640 - 1, std::max(event.motion.x, 0));
+	mouse_y = std::min(480 - 1, std::max(event.motion.y, 0));
 }
 
 //Vehicle structure that holds the current vehicle "stamp"

--- a/src/worldeditor/worldeditor.cpp
+++ b/src/worldeditor/worldeditor.cpp
@@ -102,13 +102,12 @@ WorldMapTile	copiedtiles[MAPWIDTH][MAPHEIGHT];
 int				mouse_x, mouse_y;
 
 void update_mouse_coords() {
-#ifdef USE_SDL2
-	mouse_x = (std::min)(640 - 1, (std::max)(event.motion.x, 0));
-	mouse_y = (std::min)(480 - 1, (std::max)(event.motion.y, 0));
-#else
 	mouse_x = event.motion.x;
 	mouse_y = event.motion.y;
-#endif
+	if (mouse_x < 0) mouse_x = 0;
+	if (mouse_y < 0) mouse_y = 0;
+	if (mouse_x > 640 - 1) mouse_x = 640 - 1;
+	if (mouse_y > 480 - 1) mouse_y = 480 - 1;
 }
 
 //Vehicle structure that holds the current vehicle "stamp"

--- a/src/worldeditor/worldeditor.cpp
+++ b/src/worldeditor/worldeditor.cpp
@@ -41,10 +41,6 @@
 #include <string.h>
 #include <ctype.h>
 
-#ifndef USE_SDL2
-#include <algorithm>
-#endif
-
 #ifdef _WIN32
 	#include <windows.h>
     #ifdef _MSC_VER
@@ -106,8 +102,13 @@ WorldMapTile	copiedtiles[MAPWIDTH][MAPHEIGHT];
 int				mouse_x, mouse_y;
 
 void update_mouse_coords() {
+#ifdef USE_SDL2
 	mouse_x = std::min(640 - 1, std::max(event.motion.x, 0));
 	mouse_y = std::min(480 - 1, std::max(event.motion.y, 0));
+#else
+	mouse_x = event.motion.x;
+	mouse_y = event.motion.y;
+#endif
 }
 
 //Vehicle structure that holds the current vehicle "stamp"

--- a/src/worldeditor/worldeditor.cpp
+++ b/src/worldeditor/worldeditor.cpp
@@ -99,6 +99,8 @@ bool			selectedtiles[MAPWIDTH][MAPHEIGHT];
 bool			moveselectedtiles[MAPWIDTH][MAPHEIGHT];
 WorldMapTile	copiedtiles[MAPWIDTH][MAPHEIGHT];
 
+int				mouse_x, mouse_y;
+
 //Vehicle structure that holds the current vehicle "stamp"
 WorldVehicle g_wvVehicleStamp;
 
@@ -1153,11 +1155,8 @@ int editor_edit()
 						}
 
                     if (edit_mode == 5 && event.key.keysym.sym == SDLK_c) {
-							int iMouseX, iMouseY;
-							SDL_GetMouseState(&iMouseX, &iMouseY);
-
-							short iButtonX = iMouseX - draw_offset_x;
-							short iButtonY = iMouseY - draw_offset_y;
+							short iButtonX = mouse_x - draw_offset_x;
+							short iButtonY = mouse_y - draw_offset_y;
 							short iCol = iButtonX / TILESIZE + draw_offset_col;
 							short iRow = iButtonY / TILESIZE + draw_offset_row;
 
@@ -1490,6 +1489,8 @@ int editor_edit()
 					}
 					//Painting tiles with mouse movement
                 case SDL_MOUSEMOTION: {
+						mouse_x = event.button.x;
+						mouse_y = event.button.y;
 						short iButtonX = event.button.x - draw_offset_x;
 						short iButtonY = event.button.y - draw_offset_y;
 						short iCol = (iButtonX >> 5) + draw_offset_col;
@@ -1796,10 +1797,7 @@ int editor_edit()
 				}
 
                 if (iStageDisplay >= 0 && g_fShowStagePreviews) {
-					int iMouseX, iMouseY;
-					SDL_GetMouseState(&iMouseX, &iMouseY);
-
-					DisplayStageDetails(false, iStageDisplay, iMouseX, iMouseY);
+					DisplayStageDetails(false, iStageDisplay, mouse_x, mouse_y);
 				}
 			}
 
@@ -1834,10 +1832,7 @@ int editor_edit()
 
                 if (edit_mode == 5) {
                     if (iStageDisplay >= 0) {
-						int iMouseX, iMouseY;
-						SDL_GetMouseState(&iMouseX, &iMouseY);
-
-						DisplayStageDetails(false, iStageDisplay, iMouseX, iMouseY);
+						DisplayStageDetails(false, iStageDisplay, mouse_x, mouse_y);
 					}
 				}
 			}
@@ -3931,10 +3926,7 @@ int editor_stage()
                     if (ts->iStageType == 0) {
 							short iPlace = event.key.keysym.sym - SDLK_1 + 1;
 
-							int iMouseX, iMouseY;
-							SDL_GetMouseState(&iMouseX, &iMouseY);
-
-							TestAndSetBonusItem(ts, iPlace, iMouseX, iMouseY);
+							TestAndSetBonusItem(ts, iPlace, mouse_x, mouse_y);
 						}
                 } else if ((event.key.keysym.sym == SDLK_PAGEUP && iEditStage > 0) ||
                           (event.key.keysym.sym == SDLK_PAGEDOWN && iEditStage < g_worldmap.iNumStages - 1)) {
@@ -4027,6 +4019,8 @@ int editor_stage()
 				}
 
             case SDL_MOUSEMOTION: {
+					mouse_x = event.button.x;
+					mouse_y = event.button.y;
 					iStageDisplay = -1;
 
                 if (iEditStage == -1) {
@@ -4242,10 +4236,7 @@ int editor_stage()
 			}
 
             if (iStageDisplay >= 0) {
-				int iMouseX, iMouseY;
-				SDL_GetMouseState(&iMouseX, &iMouseY);
-
-				DisplayStageDetails(fForceStageDisplay, iStageDisplay, iMouseX, iMouseY);
+				DisplayStageDetails(fForceStageDisplay, iStageDisplay, mouse_x, mouse_y);
 				fForceStageDisplay = false;
 			}
 


### PR DESCRIPTION
For some reason, SDL_GetMouseState() was returning the wrong values for the mouse x and y position in fullscreen mode (and also when you stretch the screen with my other pull request), which broke the following features:
- Pressing K when hovering over a block
- The names of the backgrounds when hovering over thumbnails
- The highlight effect when hovering the mouse over eyecandy/block properties.
- The tooltip when hovering over stages in the world editor.
etc.