### PR TITLE
AI Tweaks

### DIFF
--- a/src/smw/ai.cpp
+++ b/src/smw/ai.cpp
@@ -286,13 +286,11 @@ void CPlayerAI::Think(COutputControl * playerKeys)
                 if (!pPlayer->inair) playerKeys->game_down.fDown = true;
 
                 if (!pPlayer->superstomp.isInSuperStompState()) {
-                    //If the player is tanooki, then try to super stomp on them
-                    if (pPlayer->tanookisuit.isOn()) {
-                        playerKeys->game_turbo.fPressed = true;
-                        pPlayer->lockfire = false;
-                    } else if (pPlayer->kuriboshoe.is_on()) { //else if the player has the shoe then stomp
-                        playerKeys->game_down.fPressed = true;
+                    //If the player has the tanooki or shoe, then try to super stomp on them
+                    if (pPlayer->tanookisuit.isOn() || pPlayer->kuriboshoe.is_on()) {
+                        playerKeys->game_down.fDown = true;
                         playerKeys->game_jump.fPressed = true;
+                        if (pPlayer->tanookisuit.isOn()) pPlayer->lockfire = false;
                     }
                 }
             }
@@ -397,13 +395,11 @@ void CPlayerAI::Think(COutputControl * playerKeys)
                 if (!pPlayer->inair) playerKeys->game_down.fDown = true;
 
                 if (!pPlayer->superstomp.isInSuperStompState()) {
-                    //If the player is tanooki, then try to super stomp on them
-                    if (pPlayer->tanookisuit.isOn()) {
-                        playerKeys->game_turbo.fPressed = true;
-                        pPlayer->lockfire = false;
-                    } else if (pPlayer->kuriboshoe.is_on()) { //else if the player has the shoe then stomp
-                        playerKeys->game_down.fPressed = true;
+                    //If the player has the tanooki or shoe, then try to super stomp on them
+                    if (pPlayer->tanookisuit.isOn() || pPlayer->kuriboshoe.is_on()) {
+                        playerKeys->game_down.fDown = true;
                         playerKeys->game_jump.fPressed = true;
+                        if (pPlayer->tanookisuit.isOn()) pPlayer->lockfire = false;
                     }
                 }
             }
@@ -417,6 +413,10 @@ void CPlayerAI::Think(COutputControl * playerKeys)
     //Pick up throwable blocks from below
     if (playerKeys->game_turbo.fDown && !carriedItem && !pPlayer->inair)
         playerKeys->game_turbo.fPressed = true;
+
+    //Stay inside tanooki statue
+    if (pPlayer->tanookisuit.isOn() && pPlayer->tanookisuit.isStatue())
+        playerKeys->game_down.fDown = true;
 
     //"Star Mode" specific stuff
     //Drop the star if we're not it

--- a/src/smw/ai.cpp
+++ b/src/smw/ai.cpp
@@ -499,7 +499,7 @@ void CPlayerAI::Think(COutputControl * playerKeys)
 
             goto ExitDeathCheck;
         } else if ((ttLeftTile & tile_flag_solid) || (ttLeftTile & tile_flag_solid_on_top) || g_map->block(iDeathX1, iDeathY) ||
-                  ((ttRightTile & tile_flag_solid) && (ttRightTile & tile_flag_solid_on_top)) || g_map->block(iDeathX2, iDeathY)) {
+                  (ttRightTile & tile_flag_solid) || (ttRightTile & tile_flag_solid_on_top) || g_map->block(iDeathX2, iDeathY)) {
             iFallDanger = 0;
             goto ExitDeathCheck;
         }
@@ -520,7 +520,7 @@ void CPlayerAI::Think(COutputControl * playerKeys)
 
                 goto ExitDeathCheck;
             } else if ((lefttile & tile_flag_solid) || (lefttile & tile_flag_solid_on_top) ||
-                      ((righttile & tile_flag_solid) && (righttile & tile_flag_solid_on_top))) {
+                      (righttile & tile_flag_solid) || (righttile & tile_flag_solid_on_top)) {
                 iFallDanger = 0;
                 goto ExitDeathCheck;
             }

--- a/src/smw/ai.cpp
+++ b/src/smw/ai.cpp
@@ -290,7 +290,11 @@ void CPlayerAI::Think(COutputControl * playerKeys)
                     if (pPlayer->tanookisuit.isOn() || pPlayer->kuriboshoe.is_on()) {
                         playerKeys->game_down.fDown = true;
                         playerKeys->game_jump.fPressed = true;
-                        if (pPlayer->tanookisuit.isOn()) pPlayer->lockfire = false;
+                        if (pPlayer->tanookisuit.isOn())
+                        {
+                            playerKeys->game_turbo.fPressed = true;
+                            pPlayer->lockfire = false;
+                        }
                     }
                 }
             }
@@ -399,7 +403,11 @@ void CPlayerAI::Think(COutputControl * playerKeys)
                     if (pPlayer->tanookisuit.isOn() || pPlayer->kuriboshoe.is_on()) {
                         playerKeys->game_down.fDown = true;
                         playerKeys->game_jump.fPressed = true;
-                        if (pPlayer->tanookisuit.isOn()) pPlayer->lockfire = false;
+                        if (pPlayer->tanookisuit.isOn())
+                        {
+                            playerKeys->game_turbo.fPressed = true;
+                            pPlayer->lockfire = false;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
- Ignore threats when invincible.
- When choosing priority of actions, use 8100 so that the run away from players code executes.
- Fix not being able to super stomp when both the tanooki and shoe are equipped at the same time.
- Fix AI spamming the tanooki instead of staying inside the statue.
- Allow AI to pick up throwable blocks from below.
- Fixed logic errors with falling on spikes code. (Someone messed this up in an earlier commit)
- Add code to stop AI from spamming the jump button in 1 tile high gaps when they want to jump there.