### PR TITLE
Fix carried items maintaining velocity when picked up and dropped

### DIFF
--- a/src/smw/player.cpp
+++ b/src/smw/player.cpp
@@ -2832,6 +2832,8 @@ bool CPlayer::AcceptItem(MO_CarriedObject * item)
 
         carriedItem = item;
         item->owner = this;
+        carriedItem->velx = 0.0f;
+        carriedItem->vely = 0.0f;
 
         fAcceptingItem = false;
         return true;


### PR DESCRIPTION
Someone posted a video of this on Discord, and it's an easy fix, so I patched it.
https://www.youtube.com/watch?v=idjfJfZqYMw