### PR TITLE
Fix carriable objects sometimes crashing the game.

### DIFF
--- a/src/smw/objectgame.cpp
+++ b/src/smw/objectgame.cpp
@@ -2375,7 +2375,10 @@ MO_CarriedObject::MO_CarriedObject(gfxSprite *nspr, short x, short y, short iNum
 }
 
 MO_CarriedObject::~MO_CarriedObject()
-{}
+{
+    if (owner)
+        owner->carriedItem = NULL;
+}
 
 void MO_CarriedObject::init()
 {


### PR DESCRIPTION
Fixes #155 
MO_CarriedObject is also of type IO_MovingObject, so if the object is destroyed as a IO_MovingObject, carriedItem won't be set to NULL.