### PR TITLE
Do not play starman theme if music is muted.

### DIFF
--- a/src/smw/GSGameplay.cpp
+++ b/src/smw/GSGameplay.cpp
@@ -1751,7 +1751,7 @@ void playMusic()
             ifsoundonstop(rm->sfx_slowdownmusic);
     }
 
-    if (game_values.playinvinciblesound) {
+    if (game_values.playinvinciblesound && game_values.musicvolume > 0) {
         if (!rm->sfx_invinciblemusic.isPlaying() && !rm->sfx_timewarning.isPlaying() && !rm->backgroundmusic[0].isplaying())
             ifSoundOnPlay(rm->sfx_invinciblemusic);
     } else {


### PR DESCRIPTION
Fixes #161 
The starman theme is currently part of sound packs instead of music packs, so it technically counts as sfx, so this isn't a proper fix, but it does work.