### PR TITLE
Fix poison mushrooms sometimes spawning when they shouldn't

### DIFF
--- a/src/smw/objects/blocks/PowerupBlock.cpp
+++ b/src/smw/objects/blocks/PowerupBlock.cpp
@@ -325,7 +325,7 @@ short B_PowerupBlock::SelectPowerup()
     if (iCountWeight == 0)
         return NO_POWERUP;
 
-    int iRandPowerup = RANDOM_INT(iCountWeight + 1);
+    int iRandPowerup = RANDOM_INT(iCountWeight) + 1;
     int iSelectedPowerup = 0;
 
     int iPowerupWeightCount = settings[iSelectedPowerup];


### PR DESCRIPTION
I changed the code for question blocks to match the code for view blocks [right here](https://github.com/mmatyas/supermariowar/blob/master/src/smw/objects/blocks/ViewBlock.cpp#L63), and this seems to fix the problem.