### PR TITLE
Don't allow releasing another stored powerup when you're in the middle of releasing one

### DIFF
--- a/src/smw/player.cpp
+++ b/src/smw/player.cpp
@@ -1007,6 +1007,10 @@ void CPlayer::tryReleasingPowerup()
     if (game_values.gamepowerups[globalID] <= 0 || shyguy)
         return;
 
+    // Don't allow releasing another powerup when you're in the middle of releasing one
+    if (powerupused != -1)
+        return;
+
     powerupused = game_values.gamepowerups[globalID];
     game_values.gamepowerups[globalID] = -1;
 


### PR DESCRIPTION
If you release another powerup when you're in the middle of releasing one, the first one never gets used.