### PR TITLE
Remove WIP text from splash screen

### DIFF
--- a/src/smw/GSSplashScreen.cpp
+++ b/src/smw/GSSplashScreen.cpp
@@ -297,7 +297,7 @@ void SplashScreenState::update()
         rm->menu_version.draw(628 - rm->menu_version.getWidth(), 10); //smw logo
 
         rm->menu_font_large.setalpha((Uint8)alpha);
-        rm->menu_font_large.drawRightJustified(smw->ScreenWidth * 0.98f, 45, "WIP");
+        //rm->menu_font_large.drawRightJustified(smw->ScreenWidth * 0.98f, 45, "WIP");
 
         menu_credits->setalpha((Uint8)alpha);
         menu_credits->draw(227, 200);


### PR DESCRIPTION
It's strange that this is only on the splash screen.