### PR TITLE
Add basic controller LED (e.g. Dualshock 4) support

### DIFF
--- a/src/common/gfx.cpp
+++ b/src/common/gfx.cpp
@@ -643,7 +643,8 @@ void gfx_setjoystickteamcolor(SDL_Joystick * joystick, unsigned short team, floa
 {
 #ifdef USE_SDL2
     uint8_t r = 0, g = 0, b = 0;
+    brightness = max(0.f, min(1.f, brightness));
     gfx.getPalette().copyColorSchemeTo(team, 0, 5, r, g, b);
-    SDL_JoystickSetLED(joystick, std::clamp((int)(brightness * r), 0, 255), std::clamp((int)(brightness * g), 0, 255), std::clamp((int)(brightness * b), 0, 255));
+    SDL_JoystickSetLED(joystick, (Uint8)(brightness * r), (Uint8)(brightness * g), (Uint8)(brightness * b));
 #endif
 }

--- a/src/common/gfx.cpp
+++ b/src/common/gfx.cpp
@@ -5,6 +5,7 @@
 #include "SDL_image.h"
 #include "sdl12wrapper.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <iostream>
 #include <string>
@@ -638,9 +639,11 @@ bool gfx_loadimage(gfxSprite * gSprite, const std::string& f, Uint8 r, Uint8 g, 
     return fRet;
 }
 
-void gfx_setjoystickteamcolor(SDL_Joystick * joystick, unsigned short team, Uint8 brightness)
+void gfx_setjoystickteamcolor(SDL_Joystick * joystick, unsigned short team, float brightness)
 {
+#ifdef USE_SDL2
     uint8_t r = 0, g = 0, b = 0;
     gfx.getPalette().copyColorSchemeTo(team, 0, 5, r, g, b);
-    SDL_JoystickSetLED(joystick, ((short)brightness + 1) * r >> 8, ((short)brightness + 1) * g >> 8, ((short)brightness + 1) * b >> 8);
+    SDL_JoystickSetLED(joystick, std::clamp((int)(brightness * r), 0, 255), std::clamp((int)(brightness * g), 0, 255), std::clamp((int)(brightness * b), 0, 255));
+#endif
 }

--- a/src/common/gfx.cpp
+++ b/src/common/gfx.cpp
@@ -637,3 +637,10 @@ bool gfx_loadimage(gfxSprite * gSprite, const std::string& f, Uint8 r, Uint8 g, 
 
     return fRet;
 }
+
+void gfx_setjoystickteamcolor(SDL_Joystick * joystick, unsigned short team, Uint8 brightness)
+{
+    uint8_t r = 0, g = 0, b = 0;
+    gfx.getPalette().copyColorSchemeTo(team, 0, 5, r, g, b);
+    SDL_JoystickSetLED(joystick, ((short)brightness + 1) * r >> 8, ((short)brightness + 1) * g >> 8, ((short)brightness + 1) * b >> 8);
+}

--- a/src/common/gfx.h
+++ b/src/common/gfx.h
@@ -60,6 +60,6 @@ bool gfx_loadimage(gfxSprite * gSprite, const std::string& f, bool fWrap = true,
 bool gfx_loadimage(gfxSprite * gSprite, const std::string& f, Uint8 alpha, bool fWrap = true, bool fUseAccel = true);
 bool gfx_loadimage(gfxSprite * gSprite, const std::string& f, Uint8 r, Uint8 g, Uint8 b, bool fWrap = true, bool fUseAccel = true);
 
-void gfx_setjoystickteamcolor(SDL_Joystick * joystick, unsigned short team, Uint8 brightness);
+void gfx_setjoystickteamcolor(SDL_Joystick * joystick, unsigned short team, float brightness);
 
 #endif // GFX_H

--- a/src/common/gfx.h
+++ b/src/common/gfx.h
@@ -60,4 +60,6 @@ bool gfx_loadimage(gfxSprite * gSprite, const std::string& f, bool fWrap = true,
 bool gfx_loadimage(gfxSprite * gSprite, const std::string& f, Uint8 alpha, bool fWrap = true, bool fUseAccel = true);
 bool gfx_loadimage(gfxSprite * gSprite, const std::string& f, Uint8 r, Uint8 g, Uint8 b, bool fWrap = true, bool fUseAccel = true);
 
+void gfx_setjoystickteamcolor(SDL_Joystick * joystick, unsigned short team, Uint8 brightness);
+
 #endif // GFX_H

--- a/src/smw/ui/MI_TeamSelect.cpp
+++ b/src/smw/ui/MI_TeamSelect.cpp
@@ -1,5 +1,6 @@
 #include "MI_TeamSelect.h"
 
+#include "gfx.h"
 #include "Game.h"
 #include "GameValues.h"
 #include "ResourceManager.h"
@@ -222,6 +223,10 @@ MenuCodeEnum MI_TeamSelect::SendInput(CPlayerInput * playerInput)
                     return MENU_CODE_BACK_TO_MATCH_SELECTION_MENU;
                 }
             }
+        }
+        if (DEVICE_KEYBOARD != playerInput->inputControls[iPlayer]->iDevice) {
+            short team = GetTeam(iPlayer);
+            gfx_setjoystickteamcolor(SDL_JoystickFromPlayerIndex(playerInput->inputControls[iPlayer]->iDevice), team, fReady[iPlayer] ? 200 : 100);
         }
     }
 

--- a/src/smw/ui/MI_TeamSelect.cpp
+++ b/src/smw/ui/MI_TeamSelect.cpp
@@ -226,7 +226,7 @@ MenuCodeEnum MI_TeamSelect::SendInput(CPlayerInput * playerInput)
         }
         if (DEVICE_KEYBOARD != playerInput->inputControls[iPlayer]->iDevice) {
             short team = GetTeam(iPlayer);
-            gfx_setjoystickteamcolor(SDL_JoystickFromPlayerIndex(playerInput->inputControls[iPlayer]->iDevice), team, fReady[iPlayer] ? 200 : 100);
+            gfx_setjoystickteamcolor(SDL_JoystickFromPlayerIndex(playerInput->inputControls[iPlayer]->iDevice), team, fReady[iPlayer] ? 1.0 : 0.5);
         }
     }
 

--- a/src/smw/ui/MI_TeamSelect.cpp
+++ b/src/smw/ui/MI_TeamSelect.cpp
@@ -224,10 +224,12 @@ MenuCodeEnum MI_TeamSelect::SendInput(CPlayerInput * playerInput)
                 }
             }
         }
+#ifdef USE_SDL2
         if (DEVICE_KEYBOARD != playerInput->inputControls[iPlayer]->iDevice) {
             short team = GetTeam(iPlayer);
             gfx_setjoystickteamcolor(SDL_JoystickFromPlayerIndex(playerInput->inputControls[iPlayer]->iDevice), team, fReady[iPlayer] ? 1.0 : 0.5);
         }
+#endif
     }
 
     return MENU_CODE_NONE;


### PR DESCRIPTION
RGB controller LED lights up the team color when choosing team outside of netplay.

Magic value of 200 chosen to allow for setting the LED brighter than the normal value during gameplay events.