### PR TITLE
Fix a crash when the joystick belongs to a non-playing user

### DIFF
--- a/src/common/gfx.cpp
+++ b/src/common/gfx.cpp
@@ -489,9 +489,14 @@ bool gfx_loadimage(gfxSprite& gSprite, const std::string& path, const RGB& rgb, 
     return success;
 }
 
-void gfx_setjoystickteamcolor(SDL_Joystick* joystick, unsigned short team, float brightness)
+void gfx_setjoystickteamcolor(SDL_Joystick* joystick, short team, float brightness)
 {
 #if SDL_VERSION_ATLEAST(2, 0, 14)
+    if (team < 0) {
+        // A non-playing user has no team
+        return;
+    }
+
     brightness = max(0.f, min(1.f, brightness));
     const RGB& color = gfx.getPalette().colorScheme(team, 0, 5);
     SDL_JoystickSetLED(joystick, (Uint8)(brightness * color.r), (Uint8)(brightness * color.g), (Uint8)(brightness * color.b));

--- a/src/common/gfx.h
+++ b/src/common/gfx.h
@@ -63,7 +63,7 @@ bool gfx_loadimage(gfxSprite& sprite, const std::string& path, bool fWrap = true
 bool gfx_loadimage(gfxSprite& sprite, const std::string& path, Uint8 alpha, bool fWrap = true);
 bool gfx_loadimage(gfxSprite& sprite, const std::string& path, const RGB& rgb, bool fWrap = true);
 
-void gfx_setjoystickteamcolor(SDL_Joystick * joystick, unsigned short team, float brightness);
+void gfx_setjoystickteamcolor(SDL_Joystick * joystick, short team, float brightness);
 
 
 RGB getRgb(SDL_Surface* surf, int x, int y);


### PR DESCRIPTION
When the game is controlled by a joystick, but that joystick belongs to a player who isn't actually a player, the game tried to assign a non-existing team color.