### PR TITLE
Replace char arrays with std::string in TourStop, MI_TextField and netplay structs

### DIFF
--- a/src/common/WorldTourStop.cpp
+++ b/src/common/WorldTourStop.cpp
@@ -469,11 +469,11 @@ TourStop ParseTourStopLine(char* buffer, const Version& version, bool fIsWorld)
         pszTemp = strtok(NULL, ",\n");
     }
 
-    ts.szBonusText[0][0] = 0;
-    ts.szBonusText[1][0] = 0;
-    ts.szBonusText[2][0] = 0;
-    ts.szBonusText[3][0] = 0;
-    ts.szBonusText[4][0] = 0;
+    ts.szBonusText[0].clear();
+    ts.szBonusText[1].clear();
+    ts.szBonusText[2].clear();
+    ts.szBonusText[3].clear();
+    ts.szBonusText[4].clear();
 
     if (ts.iStageType == 0) {
         char* szMap = new char[strlen(pszTemp) + 1];
@@ -572,7 +572,7 @@ TourStop ParseTourStopLine(char* buffer, const Version& version, bool fIsWorld)
                     else if (iWinnerPlace < 1 || iWinnerPlace > 4)
                         iWinnerPlace = 1;
 
-                    strcpy(ts.wsbBonuses[ts.iNumBonuses].szBonusString, pszStart);
+                    ts.wsbBonuses[ts.iNumBonuses].szBonusString = pszStart;
 
                     ts.wsbBonuses[ts.iNumBonuses].iWinnerPlace = iWinnerPlace - 1;
 
@@ -606,15 +606,14 @@ TourStop ParseTourStopLine(char* buffer, const Version& version, bool fIsWorld)
             pszTemp = strtok(NULL, ",\n");
 
             if (pszTemp) {
-                strncpy(ts.szName, pszTemp, 127);
-                ts.szName[127] = 0;
+                ts.szName = pszTemp;
             } else {
-                sprintf(ts.szName, "Tour Stop %d", game_values.tourstops.size() + 1);
+                ts.szName = "Tour Stop " + std::to_string(game_values.tourstops.size() + 1);
             }
         } else {
             ts.iPoints = 1;
             ts.iBonusType = 0;
-            sprintf(ts.szName, "Tour Stop %d", game_values.tourstops.size() + 1);
+            ts.szName = "Tour Stop " + std::to_string(game_values.tourstops.size() + 1);
         }
 
         if (version >= Version {1, 8, 0, 0}) {
@@ -637,10 +636,9 @@ TourStop ParseTourStopLine(char* buffer, const Version& version, bool fIsWorld)
         }
     } else if (ts.iStageType == 1) { //Bonus House
         if (pszTemp) {
-            strncpy(ts.szName, pszTemp, 127);
-            ts.szName[127] = 0;
+            ts.szName = pszTemp;
         } else {
-            sprintf(ts.szName, "Bonus House %d", game_values.tourstops.size() + 1);
+            ts.szName = "Bonus House " + std::to_string(game_values.tourstops.size() + 1);
         }
 
         pszTemp = strtok(NULL, ",\n");
@@ -662,7 +660,7 @@ TourStop ParseTourStopLine(char* buffer, const Version& version, bool fIsWorld)
             if (pszEnd)
                 *pszEnd = 0;
 
-            strcpy(ts.szBonusText[ts.iBonusTextLines], pszStart);
+            ts.szBonusText[ts.iBonusTextLines] = pszStart;
 
             if (++ts.iBonusTextLines >= 5 || !pszEnd)
                 break;
@@ -673,7 +671,7 @@ TourStop ParseTourStopLine(char* buffer, const Version& version, bool fIsWorld)
         ts.iNumBonuses = 0;
         pszTemp = strtok(NULL, ",\n");
         while (pszTemp) {
-            strcpy(ts.wsbBonuses[ts.iNumBonuses].szBonusString, pszTemp);
+            ts.wsbBonuses[ts.iNumBonuses].szBonusString = pszTemp;
 
             short iPowerupOffset = 0;
             if (pszTemp[0] == 'w' || pszTemp[0] == 'W')

--- a/src/common/WorldTourStop.h
+++ b/src/common/WorldTourStop.h
@@ -2,6 +2,7 @@
 
 #include "GameModeSettings.h"
 
+#include <array>
 #include <string>
 
 struct TourStop;
@@ -11,7 +12,7 @@ struct Version;
 struct WorldStageBonus {
     short iWinnerPlace;
     short iBonus;
-    char szBonusString[8];
+    std::string szBonusString;
 };
 
 struct TourStop {
@@ -20,7 +21,7 @@ struct TourStop {
     short iGoal;
     short iPoints;
     short iBonusType;
-    char szName[128];
+    std::string szName;
 
     bool fEndStage;
     short iNumBonuses;
@@ -32,7 +33,7 @@ struct TourStop {
     GameModeSettings gmsSettings;
 
     short iBonusTextLines;
-    char szBonusText[5][128];
+    std::array<std::string, 5> szBonusText;
 };
 
 

--- a/src/common/ui/MI_TextField.cpp
+++ b/src/common/ui/MI_TextField.cpp
@@ -116,22 +116,14 @@ MenuCodeEnum MI_TextField::SendInput(CPlayerInput * playerInput)
 
             //Check to see if this is an allowed character for this field
             bool fAllowed = true;
-            for (short iIndex = 0; iIndex < 32 && szDisallowedChars[iIndex] != 0; iIndex++) {
-                if (szDisallowedChars[iIndex] == key) {
-                    fAllowed = false;
-                    break;
-                }
+            if (szDisallowedChars.find(static_cast<char>(key)) != std::string::npos) {
+                fAllowed = false;
             }
 
             //If it is an allowed character, then add it to the field
             if (fAllowed) {
+                szOutValue->insert(iCursorIndex++, 1, static_cast<char>(key));
                 iNumChars++;
-
-                for (short iCopy = iNumChars - 1; iCopy >= iCursorIndex; iCopy--) {
-                    szOutValue[iCopy + 1] = szOutValue[iCopy];
-                }
-
-                szOutValue[iCursorIndex++] = (char)key;
 
                 UpdateCursor();
                 return mcItemChangedCode;
@@ -141,21 +133,15 @@ MenuCodeEnum MI_TextField::SendInput(CPlayerInput * playerInput)
         if (iCursorIndex > 0) {
             iCursorIndex--;
             iNumChars--;
-            for (short iCopy = iCursorIndex; iCopy < iNumChars; iCopy++) {
-                szOutValue[iCopy] = szOutValue[iCopy + 1];
-            }
-            szOutValue[iNumChars] = 0;
+            szOutValue->erase(iCursorIndex, 1);
 
             UpdateCursor();
             return mcItemChangedCode;
         }
     } else if (key == SDLK_DELETE) {
         if (iCursorIndex < iNumChars) {
-            for (short iCopy = iCursorIndex; iCopy < iNumChars; iCopy++) {
-                szOutValue[iCopy] = szOutValue[iCopy + 1];
-            }
-
-            szOutValue[--iNumChars] = 0;
+            szOutValue->erase(iCursorIndex, 1);
+            iNumChars--;
 
             UpdateCursor();
             return mcItemChangedCode;
@@ -194,7 +180,7 @@ void MI_TextField::Draw()
 
     if (szOutValue) {
         if (iStringWidth <= iAllowedWidth || !fModifying) {
-            rm->menu_font_large.drawChopRight(m_pos.x + iIndent + 8, m_pos.y + 5, iAllowedWidth, szOutValue);
+            rm->menu_font_large.drawChopRight(m_pos.x + iIndent + 8, m_pos.y + 5, iAllowedWidth, szOutValue->c_str());
         } else {
             rm->menu_font_large.drawChopLeft(m_pos.x + iWidth - 16, m_pos.y + 5, iAllowedWidth, szTempValue.c_str());
         }
@@ -203,11 +189,11 @@ void MI_TextField::Draw()
     miModifyCursor->Draw();
 }
 
-void MI_TextField::SetData(char* data, short maxchars)
+void MI_TextField::SetData(std::string& data, short maxchars)
 {
     iMaxChars = maxchars;
-    szOutValue = data;
-    iCursorIndex = strlen(szOutValue);
+    szOutValue = &data;
+    iCursorIndex = static_cast<short>(szOutValue->size());
     iNumChars = iCursorIndex;
 
     szTempValue.clear();
@@ -228,7 +214,7 @@ MenuCodeEnum MI_TextField::MouseClick(short iMouseX, short iMouseY)
         char szChar[2];
         szChar[1] = 0;
         for (short iChar = 0; iChar < iNumChars; iChar++) {
-            szChar[0] = szOutValue[iChar];
+            szChar[0] = (*szOutValue)[iChar];
             iPixelCount += rm->menu_font_large.getWidth(szChar);
 
             if (iPixelCount >= iMouseX - (m_pos.x + iIndent + 8)) {
@@ -241,7 +227,7 @@ MenuCodeEnum MI_TextField::MouseClick(short iMouseX, short iMouseY)
 
     //Otherwise just check to see if we clicked on the whole control
     if (iMouseX >= m_pos.x && iMouseX < m_pos.x + iWidth && iMouseY >= m_pos.y && iMouseY < m_pos.y + 32) {
-        iCursorIndex = strlen(szOutValue);
+        iCursorIndex = static_cast<short>(szOutValue->size());
         UpdateCursor();
         return MENU_CODE_CLICKED;
     }
@@ -256,7 +242,7 @@ void MI_TextField::Refresh()
     if (!szOutValue)
         return;
 
-    SetData(szOutValue, iMaxChars);
+    SetData(*szOutValue, iMaxChars);
 }
 
 void MI_TextField::UpdateCursor()
@@ -264,7 +250,7 @@ void MI_TextField::UpdateCursor()
     if (!szOutValue)
         return;
 
-    szTempValue = szOutValue;
+    szTempValue = *szOutValue;
     szTempValue.resize(iCursorIndex);
 
     iStringWidth = rm->menu_font_large.getWidth(szTempValue.c_str());
@@ -277,6 +263,5 @@ void MI_TextField::UpdateCursor()
 
 void MI_TextField::SetDisallowedChars(const char * chars)
 {
-    strncpy(szDisallowedChars, chars, 31);
-    szDisallowedChars[31] = 0;
+    szDisallowedChars = chars;
 }

--- a/src/common/ui/MI_TextField.h
+++ b/src/common/ui/MI_TextField.h
@@ -16,17 +16,17 @@ public:
     void SetTitle(std::string name);
 
     // Gets the values of the currently selected item
-    char* GetValue() const {
-        return szOutValue;
+    const std::string& GetValue() const {
+        return *szOutValue;
     }
 
     //Called when user selects this control to change it's value
     MenuCodeEnum Modify(bool modify) override;
 
     void Clear() {
-        szOutValue[0] = 0;
+        szOutValue->clear();
         iCursorIndex = 0;
-        iNumChars = 1;
+        iNumChars = 0;
     }
 
     //Updates animations or other events every frame
@@ -47,7 +47,7 @@ public:
     }
 
     //Set where the data of this control is written to (some member of game_values probably)
-    void SetData(char* data, short maxchars);
+    void SetData(std::string& data, short maxchars);
 
     MenuCodeEnum MouseClick(short iMouseX, short iMouseY) override;
 
@@ -65,7 +65,7 @@ protected:
     gfxSprite* spr = nullptr;
     std::string szName;
     std::string szTempValue;
-    char* szOutValue = nullptr;
+    std::string* szOutValue = nullptr;
 
     short iWidth = 0;
     short iIndent = 0;
@@ -79,5 +79,5 @@ protected:
     short iStringWidth = 0;
     short iAllowedWidth = 0;
 
-    char szDisallowedChars[32];
+    std::string szDisallowedChars;
 };

--- a/src/smw/GSMenu.cpp
+++ b/src/smw/GSMenu.cpp
@@ -1184,8 +1184,8 @@ void MenuState::update()
                 mCurrentMenu = mNetNewRoomMenu.get();
                 mCurrentMenu->ResetMenu();
             } else if (MENU_CODE_NET_CHAT_SEND == code) {
-                if (strlen(netplay.mychatmessage) > 0)
-                    netplay.client.sendChatMessage(netplay.mychatmessage);
+                if (!netplay.mychatmessage.empty())
+                    netplay.client.sendChatMessage(netplay.mychatmessage.c_str());
                 else
                     code = MENU_CODE_TO_NET_ROOM_MENU;
             } else if (MENU_CODE_TO_NET_ROOM_MENU == code) {

--- a/src/smw/gamemodes/BonusHouse.cpp
+++ b/src/smw/gamemodes/BonusHouse.cpp
@@ -80,13 +80,13 @@ void CGM_Bonus::draw_background()
     //Draw Bonus House Title
     rm->menu_plain_field.draw(0, 0, 0, 0, App::screenWidth/2, 32);
     rm->menu_plain_field.draw(App::screenWidth/2, 0, 192, 0, App::screenWidth/2, 32);
-    rm->game_font_large.drawCentered(App::screenWidth/2, 5, tsTourStop->szName);
+    rm->game_font_large.drawCentered(App::screenWidth/2, 5, tsTourStop->szName.c_str());
 
     //Draw Bonus House Text
     if (tsTourStop->iBonusTextLines > 0) {
         rm->spr_worldbonushouse.draw(128, 128, 0, 64, 384, 128);
 
         for (short iTextLine = 0; iTextLine < tsTourStop->iBonusTextLines; iTextLine++)
-            rm->game_font_large.drawChopCentered(App::screenWidth/2, 132 + 24 * iTextLine, 372, tsTourStop->szBonusText[iTextLine]);
+            rm->game_font_large.drawChopCentered(App::screenWidth/2, 132 + 24 * iTextLine, 372, tsTourStop->szBonusText[iTextLine].c_str());
     }
 }

--- a/src/smw/menu/network/NetEditServersMenu.cpp
+++ b/src/smw/menu/network/NetEditServersMenu.cpp
@@ -18,7 +18,7 @@ UI_NetEditServersMenu::UI_NetEditServersMenu()
     : UI_Menu()
 {
     currentState = DEFAULT;
-    std::fill(dialogTextData, dialogTextData + 128, 0);
+    dialogTextData.clear();
 
     miBackButton = new MI_Button(&rm->spr_selectfield, 544, 432, "Back", 80, TextAlign::CENTER);
     miBackButton->SetCode(MENU_CODE_TO_NET_SERVERS_MENU);
@@ -168,7 +168,7 @@ void UI_NetEditServersMenu::onEntrySelect()
 
     switch (currentState) {
     case EDIT:
-        strncpy(dialogTextData, netplay.savedServers[miServerScroll->CurrentIndex()].hostname.c_str(), 127);
+        dialogTextData = netplay.savedServers[miServerScroll->CurrentIndex()].hostname;
         miDialogTextField->Refresh();
         ShowDialog();
         setInitialFocus(miDialogTextField);
@@ -211,7 +211,7 @@ void UI_NetEditServersMenu::onDialogOk()
         assert(false);
     }
 
-    std::fill(dialogTextData, dialogTextData + 128, 0);
+    dialogTextData.clear();
     miDialogTextField->Refresh();
     Restore();
 }

--- a/src/smw/menu/network/NetEditServersMenu.h
+++ b/src/smw/menu/network/NetEditServersMenu.h
@@ -2,6 +2,8 @@
 
 #include "uimenu.h"
 
+#include <string>
+
 class MI_Button;
 class MI_Image;
 class MI_StringScroll;
@@ -48,7 +50,7 @@ private:
     MI_Button* miDialogOK;
     MI_Button* miDialogCancel;
 
-    char dialogTextData[128];
+    std::string dialogTextData;
 
     MI_Image* miLeftHeaderBar;
     MI_Image* miRightHeaderBar;

--- a/src/smw/menu/network/NetNewRoomMenu.cpp
+++ b/src/smw/menu/network/NetNewRoomMenu.cpp
@@ -55,7 +55,7 @@ UI_NetNewRoomMenu::UI_NetNewRoomMenu()
 
 void UI_NetNewRoomMenu::CreateInProgress()
 {
-    if (strlen(netplay.newroom_name) > 2) {
+    if (netplay.newroom_name.size() > 2) {
         netplay.client.sendCreateRoomMessage();
         netplay.operationInProgress = true;
 

--- a/src/smw/net.cpp
+++ b/src/smw/net.cpp
@@ -142,15 +142,15 @@ bool net_init()
     netplay.joinSuccessful = false;
     netplay.gameRunning = false;
 
-    strcpy(netplay.myPlayerName, "Player");
+    netplay.myPlayerName = "Player";
     netplay.currentMenuChanged = false;
     netplay.theHostIsMe = false;
     netplay.selectedRoomIndex = 0;
     netplay.selectedServerIndex = 0;
-    netplay.roomFilter[0] = '\0';
-    netplay.newroom_name[0] = '\0';
-    netplay.newroom_password[0] = '\0';
-    netplay.mychatmessage[0] = '\0';
+    netplay.roomFilter.clear();
+    netplay.newroom_name.clear();
+    netplay.newroom_password.clear();
+    netplay.mychatmessage.clear();
     netplay.allowMapCollisionEvent = false;
 
     if (!networkHandler.init())
@@ -383,7 +383,7 @@ void NetClient::handleNewRoomListEntry(const uint8_t* data, size_t dataLength)
 
 void NetClient::sendCreateRoomMessage()
 {
-    NetPkgs::NewRoom msg(netplay.newroom_name, netplay.newroom_password);
+    NetPkgs::NewRoom msg(netplay.newroom_name.c_str(), netplay.newroom_password.c_str());
     msg.gamemodeID = currentgamemode;
     game_values.gamemode = gamemodes[currentgamemode];
     msg.gamemodeGoal = game_values.gamemode->goal;
@@ -398,8 +398,8 @@ void NetClient::handleRoomCreatedMessage(const uint8_t* data, size_t dataLength)
     NetPkgs::NewRoomCreated pkg;
     memcpy(&pkg, data, sizeof(NetPkgs::NewRoomCreated));
 
-    assert(strlen(netplay.myPlayerName) <= NET_MAX_PLAYER_NAME_LENGTH);
-    assert(strlen(netplay.newroom_name) <= NET_MAX_ROOM_NAME_LENGTH);
+    assert(netplay.myPlayerName.size() <= NET_MAX_PLAYER_NAME_LENGTH);
+    assert(netplay.newroom_name.size() <= NET_MAX_ROOM_NAME_LENGTH);
 
     netplay.currentRoom.roomID = pkg.roomID;
     netplay.currentRoom.hostPlayerNumber = 0;
@@ -1002,7 +1002,7 @@ void NetClient::onConnect(NetPeer* newPeer)
     if (!foreign_lobbyserver) {
         foreign_lobbyserver = newPeer;
 
-        NetPkgs::ClientConnection message(netplay.myPlayerName);
+        NetPkgs::ClientConnection message(netplay.myPlayerName.c_str());
         sendMessageToLobbyServer(&message, sizeof(NetPkgs::ClientConnection));
     }
     else if (!foreign_gamehost) {

--- a/src/smw/net.h
+++ b/src/smw/net.h
@@ -306,22 +306,22 @@ struct Networking {
 
     //
     NetClient client;
-    char myPlayerName[NET_MAX_PLAYER_NAME_LENGTH];    // last byte will be \0
+    std::string myPlayerName;
 
     // Server list
     unsigned short selectedServerIndex;
     std::vector<ServerAddress> savedServers;
 
     // Room list
-    char roomFilter[NET_MAX_ROOM_NAME_LENGTH];
+    std::string roomFilter;
     unsigned short selectedRoomIndex;
     std::vector<RoomListEntry> currentRooms;
     Room currentRoom;
 
     // Current room
-    char newroom_name[NET_MAX_ROOM_NAME_LENGTH];
-    char newroom_password[NET_MAX_ROOM_PASSWORD_LENGTH];
-    char mychatmessage[NET_MAX_CHAT_MSG_LENGTH];
+    std::string newroom_name;
+    std::string newroom_password;
+    std::string mychatmessage;
     std::string mapfilepath;
 
     // In-game

--- a/src/smw/network/NetConfigManager.cpp
+++ b/src/smw/network/NetConfigManager.cpp
@@ -11,7 +11,7 @@
 
 void NetConfigManager::save()
 {
-    assert(netplay.myPlayerName);
+    assert(!netplay.myPlayerName.empty());
 
     std::ofstream config(GetHomeDirectory() + "servers.yml");
     if (!config.is_open()) {
@@ -99,8 +99,7 @@ void NetConfigManager::read_playername(YAML::Node& config)
             throw std::runtime_error(err);
         }
 
-        strncpy(netplay.myPlayerName, net_player_name.c_str(), NET_MAX_PLAYER_NAME_LENGTH);
-        netplay.myPlayerName[NET_MAX_PLAYER_NAME_LENGTH - 1] = '\0';
+        netplay.myPlayerName = net_player_name;
     }
     catch (std::runtime_error& error) {
         printf("[net][warning] servers.yml: %s\n", error.what());

--- a/src/worldeditor/worldeditor.cpp
+++ b/src/worldeditor/worldeditor.cpp
@@ -62,6 +62,7 @@
 
 #include <algorithm>
 #include <cstdlib>
+#include <string>
 #include <string.h>
 #include <ctype.h>
 
@@ -3280,7 +3281,7 @@ int editor_vehicles()
     for (short iStage = 0; iStage < g_worldmap.iNumStages; iStage++) {
 		TourStop * ts = game_values.tourstops[iStage];
 		char szStageName[256];
-		sprintf(szStageName, "(%d) %s", iStage + 1, ts->szName);
+		snprintf(szStageName, sizeof(szStageName), "(%d) %s", iStage + 1, ts->szName.c_str());
 
 		SF_ListItem<short>& item = miVehicleStageField->add(szStageName, iStage);
 		item.iconOverride = ts->iStageType == 1 ? 24 : (ts->iMode >= 1000 ? ts->iMode - 975 : ts->iMode);
@@ -3503,7 +3504,7 @@ void DisplayStageDetails(bool fForce, short iStageId, short iMouseX, short iMous
 
 	rm->menu_mode_large.draw(iMouseX + 16, iMouseY + 16, iMode << 5, 0, 32, 32);
 
-	rm->menu_font_small.drawChopRight(iMouseX + 52, iMouseY + 16, 164, ts->szName);
+	rm->menu_font_small.drawChopRight(iMouseX + 52, iMouseY + 16, 164, ts->szName.c_str());
 
 	char szPrint[128];
     if (iMode != 24) {
@@ -3567,7 +3568,7 @@ int g_iNumGameModeSettings[GAMEMODE_LAST] = {2,2,3,4,3,10,9,6,2,1,3,5,3,3,0,22,6
 
 SDL_Rect rItemDst[NUM_WORLD_ITEMS];
 
-void SetBonusString(char * szString, short iPlace, short iItem, short iStageType)
+void SetBonusString(std::string& szString, short iPlace, short iItem, short iStageType)
 {
 	char cType = 'p';
 
@@ -3579,11 +3580,13 @@ void SetBonusString(char * szString, short iPlace, short iItem, short iStageType
 		iItem -= NUM_POWERUPS;
 	}
 
+    char buf[32];
     if (iStageType == 0) {
-		sprintf(szString, "%d%c%d", iPlace, cType, iItem);
+		snprintf(buf, sizeof(buf), "%d%c%d", iPlace, cType, iItem);
     } else {
-		sprintf(szString, "%c%d", cType, iItem);
+		snprintf(buf, sizeof(buf), "%c%d", cType, iItem);
 	}
+    szString = buf;
 }
 
 void TestAndSetBonusItem(TourStop * ts, short iPlace, short iButtonX, short iButtonY)
@@ -3638,7 +3641,7 @@ void AdjustBonuses(TourStop * ts)
                 for (short iRemoveBonus = iBonus; iRemoveBonus < ts->iNumBonuses; iRemoveBonus++) {
 					ts->wsbBonuses[iRemoveBonus].iBonus = ts->wsbBonuses[iRemoveBonus + 1].iBonus;
 					ts->wsbBonuses[iRemoveBonus].iWinnerPlace = ts->wsbBonuses[iRemoveBonus + 1].iWinnerPlace;
-					strcpy(ts->wsbBonuses[iRemoveBonus].szBonusString, ts->wsbBonuses[iRemoveBonus + 1].szBonusString);
+					ts->wsbBonuses[iRemoveBonus].szBonusString = ts->wsbBonuses[iRemoveBonus + 1].szBonusString;
 				}
 			}
 		}
@@ -3799,11 +3802,11 @@ void NewStage(short * iEditStage)
 
 	ts->iStageType = 0;
 
-	ts->szBonusText[0][0] = 0;
-	ts->szBonusText[1][0] = 0;
-	ts->szBonusText[2][0] = 0;
-	ts->szBonusText[3][0] = 0;
-	ts->szBonusText[4][0] = 0;
+	ts->szBonusText[0].clear();
+	ts->szBonusText[1].clear();
+	ts->szBonusText[2].clear();
+	ts->szBonusText[3].clear();
+	ts->szBonusText[4].clear();
 
 	ts->pszMapFile = maplist->currentShortmapname();
 	ts->iMode = 0;
@@ -3817,7 +3820,7 @@ void NewStage(short * iEditStage)
 	ts->iBonusType = 0;
 	ts->iNumBonuses = 0;
 
-	sprintf(ts->szName, "Tour Stop %d", game_values.tourstops.size() + 1);
+	ts->szName = "Tour Stop " + std::to_string(game_values.tourstops.size() + 1);
 
 	ts->fEndStage = false;
 
@@ -3978,7 +3981,7 @@ int editor_stage()
                                 for (short iAdjust = iRemoveItem; iAdjust < ts->iNumBonuses - 1; iAdjust++) {
 										ts->wsbBonuses[iAdjust].iBonus = ts->wsbBonuses[iAdjust + 1].iBonus;
 										ts->wsbBonuses[iAdjust].iWinnerPlace = ts->wsbBonuses[iAdjust + 1].iWinnerPlace;
-										strcpy(ts->wsbBonuses[iAdjust].szBonusString, ts->wsbBonuses[iAdjust + 1].szBonusString);
+										ts->wsbBonuses[iAdjust].szBonusString = ts->wsbBonuses[iAdjust + 1].szBonusString;
 									}
 
 									ts->iNumBonuses--;


### PR DESCRIPTION
Addresses the open issue for modernizing unsafe C-style code.

Changes:
- WorldStageBonus::szBonusString[8] → std::string
- TourStop::szName[128] → std::string
- TourStop::szBonusText[5][128] → std::array<std::string, 5>
- MI_TextField: SetData(char*) → SetData(std::string&)
- MI_TextField::szDisallowedChars[32] → std::string
- NetPlayData: myPlayerName, roomFilter, newroom_name,
  newroom_password, mychatmessage → std::string
- NetEditServersMenu::dialogTextData[128] → std::string

Tested: built successfully on macOS (Apple M4, AppleClang 17).