### PR TITLE
Hazard death score Issue: #384

### DIFF
--- a/src/common/GameModeSettings.cpp
+++ b/src/common/GameModeSettings.cpp
@@ -3,11 +3,13 @@
 ClassicGameModeSettings::ClassicGameModeSettings()
     : style(DeathStyle::Respawn)  //Respawn on death
     , scoring(ScoringStyle::AllKills)  //All kills will score
+    , losepointsonhazarddeath(true) //Preserves the current behavior unless player turns the option off.
 {}
 
 FragGameModeSettings::FragGameModeSettings()
     : style(DeathStyle::Respawn)  //Respawn on death
     , scoring(ScoringStyle::AllKills)  //All kills will score
+    , losepointsonhazarddeath(true) //Preserves the current behavior unless player turns the option off.
 {}
 
 TimeGameModeSettings::TimeGameModeSettings()

--- a/src/common/GameModeSettings.h
+++ b/src/common/GameModeSettings.h
@@ -10,6 +10,7 @@
 struct ClassicGameModeSettings {
     DeathStyle style;		//on kill, either respawn the player or shield them and let them keep playing
     ScoringStyle scoring;	//When to credit a score, all kills or push kills only (sumo mode)
+    bool losepointsonhazarddeath; // Controls whether players lose a point when they die due to a stage hazard
 
     ClassicGameModeSettings();
 };
@@ -17,6 +18,7 @@ struct ClassicGameModeSettings {
 struct FragGameModeSettings {
     DeathStyle style;		//on kill, either respawn the player or shield them and let them keep playing
     ScoringStyle scoring;	//When to credit a score, all kills or push kills only (sumo mode)
+    bool losepointsonhazarddeath; // Controls whether players lose a point when they die due to a stage hazard
 
     FragGameModeSettings();
 };

--- a/src/common/PlayerKillStyles.h
+++ b/src/common/PlayerKillStyles.h
@@ -29,3 +29,8 @@ enum KillStyle {
     Spiny,
     Phanto,
 };
+
+constexpr bool ShouldPenalizeHazardDeath(KillStyle style, bool losePointsOnHazardDeath)
+{
+    return style != Environment || losePointsOnHazardDeath;
+}

--- a/src/smw/gamemodes/Classic.cpp
+++ b/src/smw/gamemodes/Classic.cpp
@@ -4,6 +4,7 @@
 #include "player.h"
 #include "ResourceManager.h"
 #include "Score.h"
+#include "PlayerKillStyles.h"
 
 extern CScore *score[4];
 extern short score_cnt;
@@ -82,14 +83,19 @@ PlayerKillType CGM_Classic::playerkilledself(CPlayer &player, KillStyle style)
     CGameMode::playerkilledself(player, style);
 
     if (!gameover) {
+        const bool penalizeDeath =
+            ShouldPenalizeHazardDeath(style, game_values.gamemodesettings.classic.losepointsonhazarddeath);
+
         if (fReverseScoring) {
-            player.Score().AdjustScore(1);
-        } else {
+            if (penalizeDeath)
+                player.Score().AdjustScore(1);
+        } else if (penalizeDeath) {
             player.Score().AdjustScore(-1);
 
             if (!playedwarningsound) {
                 short countscore = 0;
                 bool playwarning = false;
+
                 for (short j = 0; j < score_cnt; j++) {
                     for (short k = 0; k < score_cnt; k++) {
                         if (j == k)
@@ -116,7 +122,8 @@ PlayerKillType CGM_Classic::playerkilledself(CPlayer &player, KillStyle style)
             }
         }
 
-        if (game_values.gamemode->gamemode == game_mode_classic && game_values.gamemodesettings.classic.style == DeathStyle::Shield) {
+        if (game_values.gamemode->gamemode == game_mode_classic &&
+            game_values.gamemodesettings.classic.style == DeathStyle::Shield) {
             ifSoundOnPlay(rm->sfx_powerdown);
             player.Shield().reset();
             return PlayerKillType::NonKill;

--- a/src/smw/gamemodes/Frag.cpp
+++ b/src/smw/gamemodes/Frag.cpp
@@ -3,6 +3,7 @@
 #include "GameValues.h"
 #include "player.h"
 #include "ResourceManager.h"
+#include "PlayerKillStyles.h"
 
 extern CGameValues game_values;
 extern CResourceManager* rm;
@@ -48,9 +49,11 @@ PlayerKillType CGM_Frag::playerkilledself(CPlayer &player, KillStyle style)
     CGameMode::playerkilledself(player, style);
 
     if (!gameover) {
-        player.Score().AdjustScore(-1);
+        if (ShouldPenalizeHazardDeath(style, game_values.gamemodesettings.frag.losepointsonhazarddeath))
+            player.Score().AdjustScore(-1);
 
-        if (game_values.gamemode->gamemode == game_mode_frag && game_values.gamemodesettings.frag.style == DeathStyle::Shield) {
+        if (game_values.gamemode->gamemode == game_mode_frag &&
+            game_values.gamemodesettings.frag.style == DeathStyle::Shield) {
             ifSoundOnPlay(rm->sfx_powerdown);
             player.Shield().reset();
             return PlayerKillType::NonKill;

--- a/src/smw/menu/ModeOptionsMenu.cpp
+++ b/src/smw/menu/ModeOptionsMenu.cpp
@@ -47,10 +47,29 @@ UI_ModeOptionsMenu::UI_ModeOptionsMenu()
     miClassicModeRightHeaderBar = new MI_Image(&rm->menu_plain_field, 320, 0, 192, 0, 320, 32, 1, 1, 0);
     miClassicModeHeaderText = new MI_HeaderText("Classic Mode Menu", 320, 5);
 
-    mModeSettingsMenu[0].AddControl(miClassicModeStyleField, miClassicModeBackButton, miClassicModeScoringField, NULL, miClassicModeBackButton);
-    mModeSettingsMenu[0].AddControl(miClassicModeScoringField, miClassicModeStyleField, miClassicModeBackButton, NULL, miClassicModeBackButton);
-    mModeSettingsMenu[0].AddControl(miClassicModeHazardPenaltyField, miClassicModeScoringField, miClassicModeBackButton, NULL, miClassicModeBackButton);
-    mModeSettingsMenu[0].AddControl(miClassicModeBackButton, miClassicModeScoringField, miClassicModeStyleField, miClassicModeScoringField, NULL);
+    mModeSettingsMenu[0].AddControl(miClassicModeStyleField,
+        miClassicModeBackButton,
+        miClassicModeScoringField,
+        NULL,
+        miClassicModeBackButton);
+
+    mModeSettingsMenu[0].AddControl(miClassicModeScoringField,
+        miClassicModeStyleField,
+        miClassicModeHazardPenaltyField,
+        NULL,
+        miClassicModeBackButton);
+
+    mModeSettingsMenu[0].AddControl(miClassicModeHazardPenaltyField,
+        miClassicModeScoringField,
+        miClassicModeBackButton,
+        NULL,
+        miClassicModeBackButton);
+
+    mModeSettingsMenu[0].AddControl(miClassicModeBackButton,
+        miClassicModeHazardPenaltyField,
+        miClassicModeStyleField,
+        miClassicModeHazardPenaltyField,
+        NULL);
 
     mModeSettingsMenu[0].AddNonControl(miClassicModeLeftHeaderBar);
     mModeSettingsMenu[0].AddNonControl(miClassicModeRightHeaderBar);
@@ -90,10 +109,29 @@ UI_ModeOptionsMenu::UI_ModeOptionsMenu()
     miFragModeRightHeaderBar = new MI_Image(&rm->menu_plain_field, 320, 0, 192, 0, 320, 32, 1, 1, 0);
     miFragModeHeaderText = new MI_HeaderText("Frag Mode Menu", 320, 5);
 
-    mModeSettingsMenu[1].AddControl(miFragModeStyleField, miFragModeBackButton, miFragModeScoringField, NULL, miFragModeBackButton);
-    mModeSettingsMenu[1].AddControl(miFragModeScoringField, miFragModeStyleField, miFragModeBackButton, NULL, miFragModeBackButton);
-    mModeSettingsMenu[1].AddControl(miFragModeHazardPenaltyField, miFragModeScoringField, miFragModeBackButton, NULL, miFragModeBackButton);
-    mModeSettingsMenu[1].AddControl(miFragModeBackButton, miFragModeScoringField, miFragModeStyleField, miFragModeScoringField, NULL);
+    mModeSettingsMenu[1].AddControl(miFragModeStyleField,
+        miFragModeBackButton,
+        miFragModeScoringField,
+        NULL,
+        miFragModeBackButton);
+
+    mModeSettingsMenu[1].AddControl(miFragModeScoringField,
+        miFragModeStyleField,
+        miFragModeHazardPenaltyField,
+        NULL,
+        miFragModeBackButton);
+
+    mModeSettingsMenu[1].AddControl(miFragModeHazardPenaltyField,
+        miFragModeScoringField,
+        miFragModeBackButton,
+        NULL,
+        miFragModeBackButton);
+
+    mModeSettingsMenu[1].AddControl(miFragModeBackButton,
+        miFragModeHazardPenaltyField,
+        miFragModeStyleField,
+        miFragModeHazardPenaltyField,
+        NULL);
 
     mModeSettingsMenu[1].AddNonControl(miFragModeLeftHeaderBar);
     mModeSettingsMenu[1].AddNonControl(miFragModeRightHeaderBar);

--- a/src/smw/menu/ModeOptionsMenu.cpp
+++ b/src/smw/menu/ModeOptionsMenu.cpp
@@ -33,6 +33,13 @@ UI_ModeOptionsMenu::UI_ModeOptionsMenu()
     miClassicModeScoringField->setOutputPtr(&game_values.gamemodemenusettings.classic.scoring);
     miClassicModeScoringField->setCurrentValue(game_values.gamemodemenusettings.classic.scoring);
 
+    miClassicModeHazardPenaltyField = new MI_SelectField<bool>(&rm->spr_selectfield, 120, 280, "Hazard Penalty", 400, 180);
+    miClassicModeHazardPenaltyField->add("Off", false);
+    miClassicModeHazardPenaltyField->add("On", true);
+    miClassicModeHazardPenaltyField->setOutputPtr(&game_values.gamemodemenusettings.classic.losepointsonhazarddeath);
+    miClassicModeHazardPenaltyField->setCurrentValue(game_values.gamemodemenusettings.classic.losepointsonhazarddeath ? 1 : 0);
+    miClassicModeHazardPenaltyField->setAutoAdvance(true);
+
     miClassicModeBackButton = new MI_Button(&rm->spr_selectfield, 544, 432, "Back", 80, TextAlign::CENTER);
     miClassicModeBackButton->SetCode(MENU_CODE_BACK_TO_GAME_SETUP_MENU_FROM_MODE_SETTINGS);
 
@@ -42,6 +49,7 @@ UI_ModeOptionsMenu::UI_ModeOptionsMenu()
 
     mModeSettingsMenu[0].AddControl(miClassicModeStyleField, miClassicModeBackButton, miClassicModeScoringField, NULL, miClassicModeBackButton);
     mModeSettingsMenu[0].AddControl(miClassicModeScoringField, miClassicModeStyleField, miClassicModeBackButton, NULL, miClassicModeBackButton);
+    mModeSettingsMenu[0].AddControl(miClassicModeHazardPenaltyField, miClassicModeScoringField, miClassicModeBackButton, NULL, miClassicModeBackButton);
     mModeSettingsMenu[0].AddControl(miClassicModeBackButton, miClassicModeScoringField, miClassicModeStyleField, miClassicModeScoringField, NULL);
 
     mModeSettingsMenu[0].AddNonControl(miClassicModeLeftHeaderBar);
@@ -68,6 +76,13 @@ UI_ModeOptionsMenu::UI_ModeOptionsMenu()
     miFragModeScoringField->setOutputPtr(&game_values.gamemodemenusettings.frag.scoring);
     miFragModeScoringField->setCurrentValue(game_values.gamemodemenusettings.frag.scoring);
 
+    miFragModeHazardPenaltyField = new MI_SelectField<bool>(&rm->spr_selectfield, 120, 280, "Hazard Penalty", 400, 180);
+    miFragModeHazardPenaltyField->add("Off", false);
+    miFragModeHazardPenaltyField->add("On", true);
+    miFragModeHazardPenaltyField->setOutputPtr(&game_values.gamemodemenusettings.frag.losepointsonhazarddeath);
+    miFragModeHazardPenaltyField->setCurrentValue(game_values.gamemodemenusettings.frag.losepointsonhazarddeath ? 1 : 0);
+    miFragModeHazardPenaltyField->setAutoAdvance(true);
+
     miFragModeBackButton = new MI_Button(&rm->spr_selectfield, 544, 432, "Back", 80, TextAlign::CENTER);
     miFragModeBackButton->SetCode(MENU_CODE_BACK_TO_GAME_SETUP_MENU_FROM_MODE_SETTINGS);
 
@@ -77,6 +92,7 @@ UI_ModeOptionsMenu::UI_ModeOptionsMenu()
 
     mModeSettingsMenu[1].AddControl(miFragModeStyleField, miFragModeBackButton, miFragModeScoringField, NULL, miFragModeBackButton);
     mModeSettingsMenu[1].AddControl(miFragModeScoringField, miFragModeStyleField, miFragModeBackButton, NULL, miFragModeBackButton);
+    mModeSettingsMenu[1].AddControl(miFragModeHazardPenaltyField, miFragModeScoringField, miFragModeBackButton, NULL, miFragModeBackButton);
     mModeSettingsMenu[1].AddControl(miFragModeBackButton, miFragModeScoringField, miFragModeStyleField, miFragModeScoringField, NULL);
 
     mModeSettingsMenu[1].AddNonControl(miFragModeLeftHeaderBar);
@@ -1401,9 +1417,11 @@ void UI_ModeOptionsMenu::SetRandomGameModeSettings(short iMode)
     if (iMode == game_mode_classic) { // classic
         game_values.gamemodesettings.classic.style = miClassicModeStyleField->randomValue();
         game_values.gamemodesettings.classic.scoring = miClassicModeScoringField->randomValue();
+        game_values.gamemodesettings.classic.losepointsonhazarddeath = miClassicModeHazardPenaltyField->randomValue();
     } else if (iMode == game_mode_frag) { // frag
         game_values.gamemodesettings.frag.style = miFragModeStyleField->randomValue();
         game_values.gamemodesettings.frag.scoring = miFragModeScoringField->randomValue();
+        game_values.gamemodesettings.frag.losepointsonhazarddeath = miFragModeHazardPenaltyField->randomValue();
     } else if (iMode == game_mode_timelimit) { // time
         game_values.gamemodesettings.time.style = miTimeLimitModeStyleField->randomValue();
         game_values.gamemodesettings.time.scoring = miTimeLimitModeScoringField->randomValue();

--- a/src/smw/menu/ModeOptionsMenu.h
+++ b/src/smw/menu/ModeOptionsMenu.h
@@ -41,6 +41,7 @@ private:
     // Classic
     MI_SelectField<DeathStyle>* miClassicModeStyleField;
     MI_SelectField<ScoringStyle>* miClassicModeScoringField;
+    MI_SelectField<bool>* miClassicModeHazardPenaltyField;
     MI_Button* miClassicModeBackButton;
 
     MI_Image* miClassicModeLeftHeaderBar;
@@ -50,6 +51,7 @@ private:
     // Frag
     MI_SelectField<DeathStyle>* miFragModeStyleField;
     MI_SelectField<ScoringStyle>* miFragModeScoringField;
+    MI_SelectField<bool>* miFragModeHazardPenaltyField;
     MI_Button* miFragModeBackButton;
 
     MI_Image* miFragModeLeftHeaderBar;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,6 +2,7 @@ add_executable(smw-tests
 	runner.cpp
 	common/test_version.cpp
 	common/test_tokenize.cpp
+	common/test_hazard_death_penalty.cpp
 	common/math/test_vec2.cpp
 	common/util/test_DirIterator.cpp
 )

--- a/tests/common/test_hazard_death_penalty.cpp
+++ b/tests/common/test_hazard_death_penalty.cpp
@@ -1,0 +1,18 @@
+#include "doctest.h"
+#include "common/PlayerKillStyles.h"
+
+TEST_CASE("Hazard deaths are not penalized when the option is off")
+{
+    CHECK_FALSE(ShouldPenalizeHazardDeath(Environment, false));
+}
+
+TEST_CASE("Hazard deaths are penalized when the option is on")
+{
+    CHECK(ShouldPenalizeHazardDeath(Environment, true));
+}
+
+TEST_CASE("Non-hazard deaths are still penalized even when the option is off")
+{
+    CHECK(ShouldPenalizeHazardDeath(Stomp, false));
+    CHECK(ShouldPenalizeHazardDeath(Bomb, false));
+}

--- a/tests/common/test_hazard_death_penalty.cpp
+++ b/tests/common/test_hazard_death_penalty.cpp
@@ -1,5 +1,5 @@
 #include "doctest.h"
-#include "common/PlayerKillStyles.h"
+#include "PlayerKillStyles.h"
 
 TEST_CASE("Hazard deaths are not penalized when the option is off")
 {


### PR DESCRIPTION
## Summary

This PR adds a configurable option to control whether players lose points
when dying to environmental hazards such as lava or spikes.

## Changes

- Added a new menu option "Hazard Penalty" for Classic and Frag modes
- Default behavior preserves the original game logic
- Added helper function `ShouldPenalizeHazardDeath`
- Updated Classic and Frag scoring logic to respect the new setting
- Updated menu navigation so the new option can be selected

## Default Behavior

The option defaults to **On**, maintaining the original gameplay where
hazard deaths reduce the player's score.

## Testing

Tested in-game by:

- toggling the setting in Classic and Frag mode menus
- verifying score decreases on hazard death when enabled
- verifying score does not decrease when disabled