### PR TITLE
Improved tileset safety in the level editor

### DIFF
--- a/src/common/TilesetManager.cpp
+++ b/src/common/TilesetManager.cpp
@@ -93,7 +93,7 @@ CTileset::CTileset(std::filesystem::path dir)
 
 void CTileset::ensureLoaded()
 {
-    if (m_sprite_large)
+    if (isLoaded())
         return;
 
     m_tiletypes = readTileTypeFile(m_tileset_dir / "tileset.tls");
@@ -128,8 +128,10 @@ TileType CTileset::tileType(size_t tileCol, size_t tileRow) const
 
 void CTileset::setTileType(size_t tileCol, size_t tileRow, TileType type)
 {
-    assert(static_cast<size_t>(tileCol + tileRow * m_width) < m_tiletypes.size());
-    m_tiletypes[tileCol + tileRow * m_width] = type;
+    const size_t idx = tileCol + tileRow * m_width;
+    assert(idx < m_tiletypes.size());
+    m_tiletypes[idx] = type;
+    m_modified = true;
 }
 
 
@@ -138,6 +140,7 @@ TileType CTileset::incrementTileType(size_t tileCol, size_t tileRow)
     const size_t idx = tileCol + tileRow * m_width;
     assert(idx < m_tiletypes.size());
     m_tiletypes[idx] = NextTileType(m_tiletypes[idx]);
+    m_modified = true;
     return m_tiletypes[idx];
 }
 
@@ -147,6 +150,7 @@ TileType CTileset::decrementTileType(size_t tileCol, size_t tileRow)
     const size_t idx = tileCol + tileRow * m_width;
     assert(idx < m_tiletypes.size());
     m_tiletypes[idx] = PrevTileType(m_tiletypes[idx]);
+    m_modified = true;
     return m_tiletypes[idx];
 }
 
@@ -159,6 +163,10 @@ void CTileset::draw(DrawSize drawsize, const SDL_Rect& srcRect, SDL_Surface* dst
 
 void CTileset::saveTileset() const
 {
+    assert(isLoaded());
+    if (!isLoaded())
+        return;
+
     const fs::path tileset_path = m_tileset_dir / "tileset.tls";
     BinaryFile tsf(tileset_path, "wb");
     if (!tsf.is_open()) {
@@ -275,6 +283,9 @@ const SDL_Rect& CTilesetManager::rect(DrawSize size, size_t idx)
 
 void CTilesetManager::saveTilesets() const
 {
-    for (const CTileset& tileset : m_tilesets)
-        tileset.saveTileset();
+    for (const CTileset& tileset : m_tilesets) {
+        if (tileset.isLoaded() && tileset.isModified()) {
+            tileset.saveTileset();
+        }
+    }
 }

--- a/src/common/TilesetManager.cpp
+++ b/src/common/TilesetManager.cpp
@@ -9,6 +9,7 @@
 #include <cassert>
 #include <cstdio>
 #include <cstring>
+#include <format>
 #include <unordered_set>
 
 #if defined(__APPLE__)
@@ -121,7 +122,16 @@ const gfxSprite& CTileset::sprite(DrawSize size) const
 
 TileType CTileset::tileType(size_t tileCol, size_t tileRow) const
 {
-    assert(static_cast<size_t>(tileCol + tileRow * m_width) < m_tiletypes.size());
+    const size_t idx = tileCol + tileRow * m_width;
+    if (m_tiletypes.size() <= idx) {
+        throw std::format(
+            "The tileset at `{}`\n"
+            "tried to use an undefined tile at {}x{}\n"
+            "This happens when the `tileset.tls` file is damaged or saved incorrectly.\n"
+            "Consider downloading or saving again the tileset.",
+            m_tileset_dir.generic_string(), tileCol, tileRow);
+        return TileType::Solid;
+    }
     return m_tiletypes[tileCol + tileRow * m_width];
 }
 

--- a/src/common/TilesetManager.h
+++ b/src/common/TilesetManager.h
@@ -23,6 +23,8 @@ public:
 
     explicit CTileset(std::filesystem::path dir);
     void ensureLoaded();
+    bool isLoaded() const { return m_sprite_large.operator bool(); }
+    bool isModified() const { return m_modified; }
 
     void saveTileset() const;
 
@@ -50,6 +52,7 @@ private:
 
     short m_width = 0;
     short m_height = 0;
+    bool m_modified = false;
 };
 
 

--- a/src/common/gfx.cpp
+++ b/src/common/gfx.cpp
@@ -189,8 +189,19 @@ void gfx_settitle(const char* title) {
     gfx.setTitle(title);
 }
 
-void gfx_show_error(const char* message) {
-    gfx.showErrorBox(message);
+void gfx_show_catched_error(const std::string& error)
+{
+    std::string message = ""
+        "It seems the game has unexpectedly crashed. If you could tell us\n"
+        "what happened exactly, we might be able to fix this bug. Consider\n"
+        "reporting it on the link below, thanks!\n\n"
+        "https://github.com/mmatyas/supermariowar/issues\n\n"
+        "Sincerely,\nThe Developers";
+    if (!error.empty()) {
+        message += "\n\n\nThe error message:\n" + error;
+    }
+    fprintf(stderr, "\n%s\n", message.c_str());
+    gfx.showErrorBox(message.c_str());
 }
 
 void gfx_take_screenshot() {

--- a/src/common/gfx.h
+++ b/src/common/gfx.h
@@ -37,7 +37,7 @@ bool gfx_init(int w, int h, bool fullscreen);
 void gfx_changefullscreen(bool fullscreen);
 void gfx_flipscreen();
 void gfx_settitle(const char*);
-void gfx_show_error(const char*);
+void gfx_show_catched_error(const std::string&);
 void gfx_take_screenshot();
 
 void gfx_close();

--- a/src/leveleditor/leveleditor.cpp
+++ b/src/leveleditor/leveleditor.cpp
@@ -355,6 +355,8 @@ bool g_fFullScreen = false;
 void gameloop_frame();
 #endif
 
+void inner_main();
+
 //main main main
 int main(int argc, char *argv[])
 {
@@ -375,6 +377,31 @@ int main(int argc, char *argv[])
         RootDataDirectory = cmd.data_root;
     }
 
+    try {
+        inner_main();
+    }
+    catch (const char* what) {
+        gfx_show_catched_error(what);
+        return 1;
+    }
+    catch (const std::string& ex) {
+        gfx_show_catched_error(ex);
+        return 1;
+    }
+    catch (const std::exception& ex) {
+        gfx_show_catched_error(ex.what());
+        return 1;
+    }
+    catch (...) {
+        gfx_show_catched_error({});
+        return 1;
+    }
+
+    return 0;
+}
+
+void inner_main()
+{
 	ensureSettingsDir();
 
     /* This must occur before any data files are loaded */
@@ -656,7 +683,6 @@ void gameloop_frame()
     g_tilesetmanager->saveTilesets();
 
 	printf("\n---------------- shutdown ----------------\n");
-	return 0;
 #endif
 }
 

--- a/src/smw/main.cpp
+++ b/src/smw/main.cpp
@@ -290,22 +290,6 @@ void init_spawnlocations()
 
 void main_game();
 
-void show_catched_error(const std::string& error)
-{
-    std::string message = ""
-        "It seems the game has unexpectedly crashed. If you could tell us\n"
-        "what happened exactly, we might be able to fix this bug. Consider\n"
-        "reporting it on the link below, thanks!\n\n"
-        "https://github.com/mmatyas/supermariowar/issues\n\n"
-        "Sincerely,\nThe Developers";
-    if (!error.empty()) {
-        message += "\n\n\nThe error message:\n" + error;
-    }
-
-    fprintf(stderr, "\n%s\n", message.c_str());
-    gfx_show_error(message.c_str());
-}
-
 int main(int argc, char *argv[])
 {
     const cmd::Args cmd = cmd::parse_args(argc, argv);
@@ -327,19 +311,19 @@ int main(int argc, char *argv[])
         main_game();
     }
     catch (const char* what) {
-        show_catched_error(what);
+        gfx_show_catched_error(what);
         return 1;
     }
     catch (const std::string& ex) {
-        show_catched_error(ex);
+        gfx_show_catched_error(ex);
         return 1;
     }
     catch (const std::exception& ex) {
-        show_catched_error(ex.what());
+        gfx_show_catched_error(ex.what());
         return 1;
     }
     catch (...) {
-        show_catched_error({});
+        gfx_show_catched_error({});
         return 1;
     }
 

--- a/src/smw/world.h
+++ b/src/smw/world.h
@@ -126,7 +126,7 @@ class WorldVehicle : public WorldMovingObject
 	friend int editor_edit();
 	friend int resize_world();
 	friend int editor_vehicles();
-	friend int main(int argc, char *argv[]);
+	friend void inner_main();
 };
 
 struct WorldWarp {

--- a/src/worldeditor/worldeditor.cpp
+++ b/src/worldeditor/worldeditor.cpp
@@ -423,6 +423,8 @@ void SetStageMode(short iIndex, const char * szModeName, const char * szGoalName
 	}
 }
 
+void inner_main();
+
 //main main main
 int main(int argc, char *argv[])
 {
@@ -442,6 +444,31 @@ int main(int argc, char *argv[])
     if (!cmd.data_root.empty())
         RootDataDirectory = cmd.data_root;
 
+    try {
+        inner_main();
+    }
+    catch (const char* what) {
+        gfx_show_catched_error(what);
+        return 1;
+    }
+    catch (const std::string& ex) {
+        gfx_show_catched_error(ex);
+        return 1;
+    }
+    catch (const std::exception& ex) {
+        gfx_show_catched_error(ex.what());
+        return 1;
+    }
+    catch (...) {
+        gfx_show_catched_error({});
+        return 1;
+    }
+
+    return 0;
+}
+
+void inner_main()
+{
     ensureSettingsDir();
 
     /* This must occur before any data files are loaded */
@@ -1036,7 +1063,6 @@ int main(int argc, char *argv[])
     }
 
 	printf("\n---------------- shutdown ----------------\n");
-	return 0;
 }
 
 


### PR DESCRIPTION
Someone reported a crash when changing tilesets in the level editor. Turns out the level editor can be quite destructive.