### PR TITLE
Do not load player skins again when the necessary frames are present

### DIFF
--- a/src/common/ResourceManager.cpp
+++ b/src/common/ResourceManager.cpp
@@ -24,19 +24,29 @@ extern CGameValues game_values;
 
 bool CResourceManager::LoadMenuSkin(short playerID, short skinID, short colorID, bool fLoadBothDirections)
 {
-    try {
-        spr_player[playerID] = gfx_loadmenuskin(skinlist->at(skinID).path, colorID, fLoadBothDirections);
-        return true;
-    } catch (const std::string& what) {
-        std::cout << "ERROR: " << what << std::endl;
-        return false;
-    }
+    return LoadMenuSkin(playerID, skinlist->at(skinID).path, colorID, fLoadBothDirections);
 }
 
-bool CResourceManager::LoadMenuSkin(short playerID, const fs::path& filename, short colorID, bool fLoadBothDirections)
+bool CResourceManager::LoadMenuSkin(short playerID, const fs::path& path, short colorID, bool fLoadBothDirections)
 {
+    LoadedSpriteInfo new_info {
+        .path = path,
+        .colorScheme = colorID,
+    };
+    // We might not need to load again if all frames are present
+    // STANDING_R and RUNNING_R is always loaded, so needs no check,
+    // STANDING_L and RUNNING_L is loaded only when both directions are requested
+    if (loaded_player_sprites[playerID] == new_info) {
+        const bool both_dirs_present = spr_player[playerID][PGFX_STANDING_L] && spr_player[playerID][PGFX_RUNNING_L];
+        const bool already_loaded = !fLoadBothDirections || both_dirs_present;
+        if (already_loaded) {
+            return true;
+        }
+    }
+
     try {
-        spr_player[playerID] = gfx_loadmenuskin(filename, colorID, fLoadBothDirections);
+        spr_player[playerID] = gfx_loadmenuskin(path, colorID, fLoadBothDirections);
+        loaded_player_sprites[playerID] = std::move(new_info);
         return true;
     } catch (const std::string& what) {
         std::cout << "ERROR: " << what << std::endl;

--- a/src/common/ResourceManager.h
+++ b/src/common/ResourceManager.h
@@ -32,11 +32,19 @@ private:
 	void loadAllSprites();
 
 public:
+    struct LoadedSpriteInfo {
+        std::filesystem::path path;
+        short colorScheme;
+
+        bool operator==(const LoadedSpriteInfo&) const = default;
+    };
 
 	std::array<SpriteStrip, 4> spr_player;	//all player sprites
 	std::array<SpriteStrip, 4> spr_shyguy;
 	std::array<SpriteStrip, 4> spr_chocobo;
 	std::array<SpriteStrip, 4> spr_bobomb;
+
+        std::array<LoadedSpriteInfo, 4> loaded_player_sprites;
 
 	gfxSprite		spr_clouds;
 	gfxSprite		spr_ghosts;

--- a/src/smw/ui/MI_TournamentScoreboard.cpp
+++ b/src/smw/ui/MI_TournamentScoreboard.cpp
@@ -369,7 +369,9 @@ void MI_TournamentScoreboard::RefreshWorldScores(short gameWinner)
         for (short iPlayer = 0; iPlayer < iTeamCounts[iTeam]; iPlayer++) {
             static short iPlaceSprite[4] = {4, 0, 8, 9};
             miPlayerImages[iTeam][iPlayer]->SetPosition(m_pos.x + iScoreboardPlayerOffsetsX[iTeamCounts[iTeam] - 1][iPlayer] - 40, iTeamY + 16);
-            miPlayerImages[iTeam][iPlayer]->SetImageSource(&rm->spr_player[iTeamIDs[iTeam][iPlayer]][iPlaceSprite[game_values.tournament_scores[iTeam].wins]]);
+            const size_t player_idx = iTeamIDs[iTeam][iPlayer];
+            const size_t sprite_idx = iPlaceSprite[game_values.tournament_scores[iTeam].wins];
+            miPlayerImages[iTeam][iPlayer]->SetImageSource(&rm->spr_player[player_idx][sprite_idx]);
         }
 
         tourScores[iTeam]->SetPosition(m_pos.x + 508, iTeamY + 24);


### PR DESCRIPTION
This also fixes the missing player sprite on the tournament scoreboard.