### PR TITLE
Use the donut block's own graphic when falling

### DIFF
--- a/src/common/movingplatform.cpp
+++ b/src/common/movingplatform.cpp
@@ -133,6 +133,16 @@ TileType MovingPlatform::tileTypeAt(size_t col, size_t row) const
     return iTileType[col * iTileHeight + row];
 }
 
+//Draw a custom sprite on a tile of the platform, instead of a tileset tile
+void MovingPlatform::paintSprite(const gfxSprite& spr, size_t col, size_t row)
+{
+    const short iTileSize = iWidth / iTileWidth;
+    const Vec2i dstPos(col * iTileSize, row * iTileSize);
+
+    for (gfxSprite& platformSprite : sprites)
+        spr.draw(platformSprite.getSurface(), dstPos);
+}
+
 void MovingPlatform::draw()
 {
     //Comment this back in to see the no spawn area of the platform

--- a/src/common/movingplatform.cpp
+++ b/src/common/movingplatform.cpp
@@ -134,13 +134,13 @@ TileType MovingPlatform::tileTypeAt(size_t col, size_t row) const
 }
 
 //Draw a custom sprite on a tile of the platform, instead of a tileset tile
-void MovingPlatform::paintSprite(const gfxSprite& spr, size_t col, size_t row)
+void MovingPlatform::paintSpriteAt(const gfxSprite& spr, size_t col, size_t row)
 {
     const short iTileSize = iWidth / iTileWidth;
     const Vec2i dstPos(col * iTileSize, row * iTileSize);
 
-    for (gfxSprite& platformSprite : sprites)
-        spr.draw(platformSprite.getSurface(), dstPos);
+    for (gfxSprite& layer : sprites)
+        spr.draw(layer.getSurface(), dstPos);
 }
 
 void MovingPlatform::draw()

--- a/src/common/movingplatform.h
+++ b/src/common/movingplatform.h
@@ -55,7 +55,7 @@ class MovingPlatform
     const TilesetTile& tileAt(size_t col, size_t row) const;
     TileType tileTypeAt(size_t col, size_t row) const;
 
-    void paintSprite(const gfxSprite& spr, size_t col, size_t row);
+    void paintSpriteAt(const gfxSprite& spr, size_t col, size_t row);
 
 	protected:
 

--- a/src/common/movingplatform.h
+++ b/src/common/movingplatform.h
@@ -55,6 +55,8 @@ class MovingPlatform
     const TilesetTile& tileAt(size_t col, size_t row) const;
     TileType tileTypeAt(size_t col, size_t row) const;
 
+    void paintSprite(const gfxSprite& spr, size_t col, size_t row);
+
 	protected:
 
 		void check_map_collision_right(CPlayer * player);

--- a/src/smw/objects/blocks/DonutBlock.cpp
+++ b/src/smw/objects/blocks/DonutBlock.cpp
@@ -69,7 +69,7 @@ void B_DonutBlock::triggerBehavior(short iPlayerId)
     MovingPlatformPath * path = new FallingPath(Vec2f((float)ix + 16.0f, (float)iy + 15.8f));
     MovingPlatform * platform = new MovingPlatform({ tile }, { type }, 1, 1, 2, path, false);
     platform->SetPlayerId(iPlayerId);
-    platform->paintSprite(*spr, 0, 0);
+    platform->paintSpriteAt(*spr, 0, 0);
 
     g_map->AddTemporaryPlatform(platform);
 

--- a/src/smw/objects/blocks/DonutBlock.cpp
+++ b/src/smw/objects/blocks/DonutBlock.cpp
@@ -3,10 +3,8 @@
 #include "map.h"
 #include "movingplatform.h"
 #include "player.h"
-#include "TilesetManager.h"
 
 extern CMap* g_map;
-extern CTilesetManager* g_tilesetmanager;
 
 B_DonutBlock::B_DonutBlock(gfxSprite *nspr, Vec2s pos)
     : IO_Block(nspr, pos)
@@ -60,18 +58,18 @@ bool B_DonutBlock::hittop(CPlayer * player, bool useBehavior)
 
 void B_DonutBlock::triggerBehavior(short iPlayerId)
 {
-    //eyecandy[2].emplace<EC_FallingObject>(&rm->spr_donutblock, ix, iy, 0.0f, 0, 0, 0, 0);
-
+    //The falling block uses this block's own graphic instead of a tileset tile
     TilesetTile tile;
-    tile.iID = g_tilesetmanager->classicTilesetIndex();
-    tile.iCol = 29;
-    tile.iRow = 15;
+    tile.iID = TILESETNONE;
+    tile.iCol = 0;
+    tile.iRow = 0;
 
     TileType type = TileType::Solid;
 
     MovingPlatformPath * path = new FallingPath(Vec2f((float)ix + 16.0f, (float)iy + 15.8f));
     MovingPlatform * platform = new MovingPlatform({ tile }, { type }, 1, 1, 2, path, false);
     platform->SetPlayerId(iPlayerId);
+    platform->paintSprite(*spr, 0, 0);
 
     g_map->AddTemporaryPlatform(platform);
 


### PR DESCRIPTION
Fixes #169

## Problem

The static donut block draws its customizable graphic from `gfx/packs/<pack>/blocks/donutblock.png`, but once triggered, the falling block was drawn using a hardcoded tile of the Classic tileset (`tilesets/Classic/large.png`, col 29, row 15). Custom graphics packs that reskin `donutblock.png` would see the block revert to the stock donut graphic mid-fall.

## Solution

- Added a small `MovingPlatform::paintSprite()` method that paints an arbitrary sprite onto a tile cell of the platform's pre-rendered surfaces (the same surfaces tileset tiles are drawn to in the constructor).
- `B_DonutBlock::triggerBehavior()` now creates the temporary falling platform with a `TILESETNONE` tile and paints the block's own sprite instead. The platform keeps `TileType::Solid`, so the falling-block behavior is unchanged - only the graphic source differs.
- This also removes the `TilesetManager` dependency from `DonutBlock.cpp`.

Nothing else reads tile data from temporary platforms (map saving, previews and the level editor only inspect permanent platforms), so the `TILESETNONE` tile is safe.

Tested on Windows (MSVC): builds cleanly, unit tests pass, and the falling donut block now matches the static one in-game.